### PR TITLE
Change NVCategory values type from unsigned to signed int32

### DIFF
--- a/cpp/include/NVCategory.h
+++ b/cpp/include/NVCategory.h
@@ -91,7 +91,10 @@ public:
     int get_value(const char* str);
 
     // return category values for all indexes
-    int get_values( unsigned int* results, bool devmem=true );
+    int get_values( int* results, bool devmem=true );
+    // returns pointer to internal values array in device memory
+    const int* values_cptr();
+
     //
     int get_indexes_for( unsigned int index, unsigned int* results, bool devmem=true );
     int get_indexes_for( const char* str, unsigned int* results, bool devmem=true );

--- a/cpp/python/pycategory.cpp
+++ b/cpp/python/pycategory.cpp
@@ -157,7 +157,7 @@ static PyObject* n_get_values( PyObject* self, PyObject* args )
     PyObject* ret = PyList_New(count);
     if( count==0 )
         return ret;
-    unsigned int* devptr = (unsigned int*)PyLong_AsVoidPtr(PyTuple_GetItem(args,1));
+    int* devptr = (int*)PyLong_AsVoidPtr(PyTuple_GetItem(args,1));
     if( devptr )
     {
         tptr->get_values(devptr);
@@ -165,7 +165,7 @@ static PyObject* n_get_values( PyObject* self, PyObject* args )
     }
 
     // copy to host option
-    unsigned int* rtn = new unsigned int[count];
+    int* rtn = new int[count];
     tptr->get_values(rtn,false);
     for(size_t idx=0; idx < count; idx++)
         PyList_SetItem(ret, idx, PyLong_FromLong((long)rtn[idx]));

--- a/cpp/src/NVCategory.cu
+++ b/cpp/src/NVCategory.cu
@@ -579,15 +579,20 @@ int NVCategory::get_value(const char* str)
 }
 
 // return category values for all indexes
-int NVCategory::get_values( unsigned int* results, bool bdevmem )
+int NVCategory::get_values( int* results, bool bdevmem )
 {
     int count = (int)size();
     int* d_map = pImpl->getMapPtr();
     if( bdevmem )
-        cudaMemcpy(results,d_map,count*sizeof(unsigned int),cudaMemcpyDeviceToDevice);
+        cudaMemcpy(results,d_map,count*sizeof(int),cudaMemcpyDeviceToDevice);
     else
-        cudaMemcpy(results,d_map,count*sizeof(unsigned int),cudaMemcpyDeviceToHost);
+        cudaMemcpy(results,d_map,count*sizeof(int),cudaMemcpyDeviceToHost);
     return count;
+}
+
+const int* NVCategory::values_cptr()
+{
+    return pImpl->getMapPtr();
 }
 
 int NVCategory::get_indexes_for( unsigned int index, unsigned int* results, bool bdevmem )


### PR DESCRIPTION
Values can be negative in cases where the value exists with no key.