### PR TITLE
Split `build` and `host`

### DIFF
--- a/conda/recipes/nvstrings/meta.yaml
+++ b/conda/recipes/nvstrings/meta.yaml
@@ -25,9 +25,10 @@ build:
 
 requirements:
   build:
+    - cmake
+  host:
     - python
     - setuptools
-    - cmake
     - numba>=0.40
   run:
     - python


### PR DESCRIPTION
Fixes https://github.com/rapidsai/custrings/issues/152

In conda-build 3, the new `host` environment was created and split from `build` requirements. If both are listed, conda-build creates two separate environments each with their own requirements. The build environment is only used to provide command line tools (not libraries) for the build and the host environment is for all dependencies that are linked to the package.

Here we split the build and host environments and move `cmake` into the `build` requirements. As `cmake` depends on [`curl`]( https://github.com/conda-forge/cmake-feedstock/blob/0e23d0821f2bfa5138a0c23ae588ca0592aaac2a/recipe/meta.yaml#L36 ), which depends on [`openssl`]( https://github.com/conda-forge/curl-feedstock/blob/57f8980b294873f00d31f601b0dfde448550d0fd/recipe/meta.yaml#L42 ), it wound up in the environment. As [`openssl`]( https://github.com/conda-forge/openssl-feedstock/blob/bb919598fe39607e59c3bba9330ef5f81c01f9f0/recipe/meta.yaml#L22-L25 ) uses [`run_exports`]( https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#export-runtime-requirements ), this amounts to adding an `openssl` runtime dependency to `nvstrings`. However this is not need as `cmake` is only a build dependency. So we can move it to `build` and leave everything else in `host`, which should fix this issue.

cc @kkraus14