### PR TITLE
{REVIEW] Fix pip build & install drivers for conda build

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -54,7 +54,16 @@ conda config --set ssl_verify False
 # INSTALL - Install NVIDIA driver
 ################################################################################
 
-# Nothing to install yet
+logger "Install NVIDIA driver for CUDA $CUDA..."
+apt-get update -q
+DRIVER_VER="396.44-1"
+LIBCUDA_VER="396"
+if [ "$CUDA" == "10.0" ]; then
+  DRIVER_VER="410.72-1"
+  LIBCUDA_VER="410"
+fi
+DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+  cuda-drivers=${DRIVER_VER} libcuda1-${LIBCUDA_VER}
 
 ################################################################################
 # BUILD - Conda package builds (conda deps: libcuml <- cuml)

--- a/python/setup.py
+++ b/python/setup.py
@@ -73,7 +73,7 @@ setup(name=name,
                    CMakeExtension('NVCategory'),
                    CMakeExtension('pyniNVCategory')],
       cmdclass={'build_ext': CMakeBuildExt},
-      headers=['NVStrings.h', 'NVCategory.h'],
+      headers=['../cpp/include/NVStrings.h', '../cpp/include/NVCategory.h'],
       zip_safe=False
       )
 


### PR DESCRIPTION
Fixes the path to headers for pip package

Installs the NVIDIA drivers during cpu build so `libcuda.so` is available.