### PR TITLE
Fix for `No module named 'rave'`

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -63,7 +63,7 @@ version = os.environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev0').lstrip('v')
 setup(name=name,
       description='CUDA strings Python bindings',
       version=version,
-      py_modules=['nvstrings', 'nvcategory'],
+      py_modules=['nvstrings', 'nvcategory', 'rave'],
       url='https://github.com/rapidsai/custrings',
       author='NVIDIA Corporation',
       license=license_text,
@@ -71,9 +71,11 @@ setup(name=name,
       ext_modules=[CMakeExtension('NVStrings', '../cpp'),
                    CMakeExtension('pyniNVStrings', '../cpp'),
                    CMakeExtension('NVCategory', '../cpp'),
-                   CMakeExtension('pyniNVCategory', '../cpp')],
+                   CMakeExtension('pyniNVCategory', '../cpp'),
+                   CMakeExtension('Rave', '../cpp'),
+                   CMakeExtension('pyniRave', '../cpp')],
       cmdclass={'build_ext': CMakeBuildExt},
-      headers=['../cpp/include/NVStrings.h', '../cpp/include/NVCategory.h'],
+      headers=['../cpp/include/NVStrings.h', '../cpp/include/NVCategory.h','../cpp/include/Rave.h'],
       zip_safe=False
       )
 


### PR DESCRIPTION
After installing using `python setup.py install` Below tests failed

```
custrings/python/tests$
python test_rave.py
Traceback (most recent call last):
  File "test_rave.py", line 3, in <module>
    import nvstrings, rave
ModuleNotFoundError: No module named 'rave'
custrings/python/tests$
python -c "import rave"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'rave'
(custring)
custrings/python/tests$

```
This PR will bring `rave` module using `setup.py install`.