### PR TITLE
[REVIEW] Add ngrams function to nvtext module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Version jump from 0.3->0.7 is to align with other RAPIDS projects.
 - PR #176 Added match_strings to nvstrings
 - PR #172 Added to/from boolean conversion methods
 - PR #171 Added conversion to/from subset of ISO8601 format
+- PR #230 Add ngrams function to nvtext module
 
 ## Improvements
 

--- a/python/nvtext.py
+++ b/python/nvtext.py
@@ -1,7 +1,7 @@
 
 import pyniNVText
 import nvstrings as nvs
-
+import warnings
 
 def unique_tokens(strs, delimiter=' '):
     """
@@ -171,6 +171,9 @@ def ngrams(strs, N=2, sep='_'):
     >>> print(nvtext.ngrams(dstrings, N=2, sep='_'))
     ['this_is', 'is_my', 'my_favorite', 'favorite_book']
     """
+    warnings.warn("ngrams functionlity does not currently scale "
+                  "well to large datasets.")
+
     # Tokenize
     tokens = strs.split_record()
     tokens_combined = nvs.from_strings(tokens)

--- a/python/nvtext.py
+++ b/python/nvtext.py
@@ -1,7 +1,9 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.
 
 import pyniNVText
 import nvstrings as nvs
-import warnings
+import logging
+
 
 def unique_tokens(strs, delimiter=' '):
     """
@@ -171,7 +173,7 @@ def ngrams(strs, N=2, sep='_'):
     >>> print(nvtext.ngrams(dstrings, N=2, sep='_'))
     ['this_is', 'is_my', 'my_favorite', 'favorite_book']
     """
-    warnings.warn("ngrams functionlity does not currently scale "
+    logging.warning("ngrams functionlity does not currently scale "
                   "well to large datasets.")
 
     # Tokenize

--- a/python/nvtext.py
+++ b/python/nvtext.py
@@ -174,7 +174,7 @@ def ngrams(strs, N=2, sep='_'):
     ['this_is', 'is_my', 'my_favorite', 'favorite_book']
     """
     logging.warning("ngrams functionlity does not currently scale "
-                  "well to large datasets.")
+                    "well to large datasets.")
 
     # Tokenize
     tokens = strs.split_record()

--- a/python/nvtext.py
+++ b/python/nvtext.py
@@ -146,3 +146,54 @@ def edit_distance(strs, tgt, algo=0, devptr=0):
     """
     rtn = pyniNVText.n_edit_distance(strs, tgt, algo, devptr)
     return rtn
+
+
+def ngrams(strs, N=2, sep='_'):
+    """Generate the n-grams of an nvstrings array.
+
+    Parameters
+    ----------
+    strs : nvstrings
+        The strings for this operation.
+    N : int
+        The degree of the n-gram (number of consecutive tokens). Default of 2
+        for bigrams.
+    sep : The separator to use between within an n-gram. Default of '_'.
+
+    Returns
+    -------
+    ngrams_object : nvstrings
+
+    Examples
+    --------
+    >>> import nvstrings, nvtext
+    >>> dstrings = nvstrings.to_device(['this is my', 'favorite book'])
+    >>> print(nvtext.ngrams(dstrings, N=2, sep='_'))
+    ['this_is', 'is_my', 'my_favorite', 'favorite_book']
+    """
+    # Tokenize
+    tokens = strs.split_record()
+    tokens_combined = nvs.from_strings(tokens)
+
+    pad = nvs.to_device([''])
+    ngram_object = tokens_combined
+    total_num_of_tokens = tokens_combined.size()
+    shifted_token_collection = []
+
+    # Create shifted and padded nvstrings objects
+    for i in range(N - 1):
+        shifted_tokens = tokens_combined.remove_strings(
+            list(range(0, i + 1))
+        )
+        shifted_tokens = shifted_tokens.add_strings(
+            [pad] * (total_num_of_tokens - shifted_tokens.size())
+        )
+        shifted_token_collection.append(shifted_tokens)
+
+    # Create the n-grams from the shifted nvstrings
+    for sequence in shifted_token_collection:
+        ngram_object = ngram_object.cat(sequence, sep)
+
+    ngram_object = ngram_object.remove_strings(
+        list(range(ngram_object.size() - N + 1, ngram_object.size())))
+    return ngram_object

--- a/python/nvtext.py
+++ b/python/nvtext.py
@@ -195,5 +195,6 @@ def ngrams(strs, N=2, sep='_'):
         ngram_object = ngram_object.cat(sequence, sep)
 
     ngram_object = ngram_object.remove_strings(
-        list(range(ngram_object.size() - N + 1, ngram_object.size())))
+        list(range(ngram_object.size() - N + 1, ngram_object.size()))
+    )
     return ngram_object

--- a/python/tests/test_text.py
+++ b/python/tests/test_text.py
@@ -1,4 +1,6 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.
 
+import pytest
 import numpy as np
 import nvstrings, nvtext
 
@@ -50,3 +52,34 @@ strs2 = None
 
 strs = None
 tokens = None
+
+
+def test_ngrams():
+    # bigrams
+    strings = ['this is my favorite', 'book on my bookshelf']
+    dstrings = nvstrings.to_device(strings)
+    expected =[
+        'this_is',
+        'is_my',
+        'my_favorite',
+        'favorite_book',
+        'book_on',
+        'on_my',
+        'my_bookshelf'
+    ]
+    outcome = nvtext.ngrams(dstrings, N=2, sep='_')
+    assert outcome.to_host() == expected
+
+    # trigrams
+    strings = ['this is my favorite', 'book on my bookshelf']
+    dstrings = nvstrings.to_device(strings)
+    expected = [
+        'this-is-my',
+        'is-my-favorite',
+        'my-favorite-book',
+        'favorite-book-on',
+        'book-on-my',
+        'on-my-bookshelf'
+    ]
+    outcome = nvtext.ngrams(dstrings, N=3, sep='-')
+    assert outcome.to_host() == expected

--- a/python/tests/test_text.py
+++ b/python/tests/test_text.py
@@ -58,7 +58,7 @@ def test_ngrams():
     # bigrams
     strings = ['this is my favorite', 'book on my bookshelf']
     dstrings = nvstrings.to_device(strings)
-    expected =[
+    expected = [
         'this_is',
         'is_my',
         'my_favorite',


### PR DESCRIPTION
**Summary of Changes**
- This PR introduces the `ngrams` function to the nvtext module, which allows users to generate n-grams from an nvstrings object through an easy API without waiting for a CUDA/C++ implementation

**Limitations**
- Because generating n-grams requires tokenizing and shifting, which can only be done by splitting (for tokenize) and recombining (for shifting) this does not scale well to large datasets.
    - More than 99.9% of the time is spent splitting and recombining, with the significant majority spent recombining.

This PR closes #224 