### PR TITLE
[REVIEW] Fix gil python bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Version jump from 0.3->0.7 is to align with other RAPIDS projects.
 - PR #181 Update python docstrings to numpydoc style
 - PR #196 Include nvtext in python module setup
 - PR #221 Create separate conda packages for libnvstrings and nvstrings
+- PR #247 Release Python GIl while calling underlying C++ API from python
 
 ## Bug Fixes
 - PR #248 Fixed docstring for index,rindex,find,rfind

--- a/python/cpp/pycategory.cpp
+++ b/python/cpp/pycategory.cpp
@@ -75,7 +75,10 @@ static PyObject* n_createCategoryFromNVStrings( PyObject* self, PyObject* args )
         Py_RETURN_NONE;
     }
 
-    NVCategory* thisptr = NVCategory::create_from_strings(strslist);
+    NVCategory* thisptr = nullptr;
+    Py_BEGIN_ALLOW_THREADS
+    thisptr = NVCategory::create_from_strings(strslist);
+    Py_END_ALLOW_THREADS
     return PyLong_FromVoidPtr((void*)thisptr);
 }
 
@@ -111,7 +114,10 @@ static PyObject* n_createCategoryFromHostStrings( PyObject* self, PyObject* args
             list[idx] = PyUnicode_AsUTF8(pystr);
     }
     //
-    NVCategory* thisptr = NVCategory::create_from_array(list,count);
+    NVCategory* thisptr = nullptr;
+    Py_BEGIN_ALLOW_THREADS
+    thisptr = NVCategory::create_from_array(list,count);
+    Py_END_ALLOW_THREADS
     delete list;
     return PyLong_FromVoidPtr((void*)thisptr);
 }
@@ -169,7 +175,10 @@ static PyObject* n_createFromOffsets( PyObject* self, PyObject* args )
     //printf(" ptrs=%p,%p,%p\n",sbuffer,obuffer,nbuffer);
     //printf(" scount=%d,ncount=%d\n",scount,ncount);
     // create strings object from these buffers
-    NVCategory* rtn = NVCategory::create_from_offsets(sbuffer,scount,obuffer,nbuffer,ncount);
+    NVCategory* rtn = nullptr;
+    Py_BEGIN_ALLOW_THREADS
+    rtn = NVCategory::create_from_offsets(sbuffer,scount,obuffer,nbuffer,ncount);
+    Py_END_ALLOW_THREADS
 
     if( PyObject_CheckBuffer(pysbuf) )
         PyBuffer_Release(&sbuf);
@@ -188,28 +197,39 @@ static PyObject* n_destroyCategory( PyObject* self, PyObject* args )
 {
     NVCategory* tptr = (NVCategory*)PyLong_AsVoidPtr(PyTuple_GetItem(args,0));
     //printf("destroy: self=%p,args=%p,ptr=%p\n",(void*)self,(void*)args,(void*)tptr);
+    Py_BEGIN_ALLOW_THREADS
     NVCategory::destroy(tptr);
+    Py_END_ALLOW_THREADS
     return PyLong_FromLong(0);
 }
 
 static PyObject* n_size( PyObject* self, PyObject* args )
 {
     NVCategory* tptr = (NVCategory*)PyLong_AsVoidPtr(PyTuple_GetItem(args,0));
-    size_t count = tptr->size();
+    size_t count = 0;
+    Py_BEGIN_ALLOW_THREADS
+    count = tptr->size();
+    Py_END_ALLOW_THREADS
     return PyLong_FromLong(count);
 }
 
 static PyObject* n_keys_size( PyObject* self, PyObject* args )
 {
     NVCategory* tptr = (NVCategory*)PyLong_AsVoidPtr(PyTuple_GetItem(args,0));
-    size_t count = tptr->keys_size();
+    size_t count = 0;
+    Py_BEGIN_ALLOW_THREADS
+    count = tptr->keys_size();
+    Py_END_ALLOW_THREADS
     return PyLong_FromLong(count);
 }
 
 static PyObject* n_get_keys( PyObject* self, PyObject* args )
 {
     NVCategory* tptr = (NVCategory*)PyLong_AsVoidPtr(PyTuple_GetItem(args,0));
-    NVStrings* strs = tptr->get_keys();
+    NVStrings* strs = nullptr;
+    Py_BEGIN_ALLOW_THREADS
+    strs = tptr->get_keys();
+    Py_END_ALLOW_THREADS
     if( strs )
         return PyLong_FromVoidPtr((void*)strs);
     Py_RETURN_NONE;
@@ -219,7 +239,11 @@ static PyObject* n_get_value_for_index( PyObject* self, PyObject* args )
 {
     NVCategory* tptr = (NVCategory*)PyLong_AsVoidPtr(PyTuple_GetItem(args,0));
     unsigned int index = (unsigned int)PyLong_AsLong(PyTuple_GetItem(args,1));
-    return PyLong_FromLong(tptr->get_value(index));
+    int value = 0;
+    Py_BEGIN_ALLOW_THREADS
+    value = tptr->get_value(index);
+    Py_END_ALLOW_THREADS
+    return PyLong_FromLong(value);
 }
 
 static PyObject* n_get_value_for_string( PyObject* self, PyObject* args )
@@ -230,7 +254,9 @@ static PyObject* n_get_value_for_string( PyObject* self, PyObject* args )
     const char* str = 0;
     if( argStr != Py_None )
         str = PyUnicode_AsUTF8(argStr);
+    Py_BEGIN_ALLOW_THREADS
     rtn = tptr->get_value(str);
+    Py_END_ALLOW_THREADS
     return PyLong_FromLong(rtn);
 }
 
@@ -244,13 +270,17 @@ static PyObject* n_get_values( PyObject* self, PyObject* args )
     int* devptr = (int*)PyLong_AsVoidPtr(PyTuple_GetItem(args,1));
     if( devptr )
     {
+        Py_BEGIN_ALLOW_THREADS
         tptr->get_values(devptr);
+        Py_END_ALLOW_THREADS
         return PyLong_FromVoidPtr((void*)devptr);
     }
 
     // copy to host option
     int* rtn = new int[count];
+    Py_BEGIN_ALLOW_THREADS
     tptr->get_values(rtn,false);
+    Py_END_ALLOW_THREADS
     for(unsigned idx=0; idx < count; idx++)
         PyList_SetItem(ret, idx, PyLong_FromLong((long)rtn[idx]));
     delete rtn;
@@ -260,7 +290,10 @@ static PyObject* n_get_values( PyObject* self, PyObject* args )
 static PyObject* n_get_values_cpointer( PyObject* self, PyObject* args )
 {
     NVCategory* tptr = (NVCategory*)PyLong_AsVoidPtr(PyTuple_GetItem(args,0));
-    const int* vptr = tptr->values_cptr();
+    const int * vptr = nullptr;
+    Py_BEGIN_ALLOW_THREADS
+    vptr = tptr->values_cptr();
+    Py_END_ALLOW_THREADS
     return PyLong_FromVoidPtr((void*)vptr);
 }
 
@@ -274,13 +307,19 @@ static PyObject* n_get_indexes_for_key( PyObject* self, PyObject* args )
         str = PyUnicode_AsUTF8(argStr);
     if( devptr )
     {
-        int count = tptr->get_indexes_for(str,devptr);
+        int count = 0;
+        Py_BEGIN_ALLOW_THREADS
+        count = tptr->get_indexes_for(str,devptr);
+        Py_END_ALLOW_THREADS
         if( count < 0 )
             PyErr_Format(PyExc_ValueError,"nvcategory: string not found in keys");
         return PyLong_FromLong(count);
     }
     //
-    int count = tptr->get_indexes_for(str,0,false);
+    int count = 0;
+    Py_BEGIN_ALLOW_THREADS
+    count = tptr->get_indexes_for(str,0,false);
+    Py_END_ALLOW_THREADS
     if( count < 0 )
     {
         PyErr_Format(PyExc_ValueError,"nvcategory: string not found in keys");
@@ -291,7 +330,9 @@ static PyObject* n_get_indexes_for_key( PyObject* self, PyObject* args )
         return ret;
     // copy to host option
     int* rtn = new int[count];
+    Py_BEGIN_ALLOW_THREADS
     tptr->get_indexes_for(str,rtn,false);
+    Py_END_ALLOW_THREADS
     for(int idx=0; idx < count; idx++)
         PyList_SetItem(ret, idx, PyLong_FromLong((long)rtn[idx]));
     delete rtn;
@@ -320,7 +361,10 @@ static PyObject* n_add_strings( PyObject* self, PyObject* args )
         Py_RETURN_NONE;
     }
 
-    NVCategory* rtn = tptr->add_strings(*strs);
+    NVCategory* rtn = nullptr;
+    Py_BEGIN_ALLOW_THREADS
+    rtn = tptr->add_strings(*strs);
+    Py_END_ALLOW_THREADS
     if( rtn )
         return PyLong_FromVoidPtr((void*)rtn);
     Py_RETURN_NONE;
@@ -348,7 +392,10 @@ static PyObject* n_remove_strings( PyObject* self, PyObject* args )
         Py_RETURN_NONE;
     }
 
-    NVCategory* rtn = tptr->remove_strings(*strs);
+    NVCategory* rtn = nullptr;
+    Py_BEGIN_ALLOW_THREADS
+    rtn = tptr->remove_strings(*strs);
+    Py_END_ALLOW_THREADS
     if( rtn )
         return PyLong_FromVoidPtr((void*)rtn);
     Py_RETURN_NONE;
@@ -357,7 +404,10 @@ static PyObject* n_remove_strings( PyObject* self, PyObject* args )
 static PyObject* n_to_strings( PyObject* self, PyObject* args )
 {
     NVCategory* tptr = (NVCategory*)PyLong_AsVoidPtr(PyTuple_GetItem(args,0));
-    NVStrings* strs = tptr->to_strings();
+    NVStrings* strs = nullptr;
+    Py_BEGIN_ALLOW_THREADS
+    strs = tptr->to_strings();
+    Py_END_ALLOW_THREADS
     if( strs )
         return PyLong_FromVoidPtr((void*)strs);
     Py_RETURN_NONE;
@@ -381,7 +431,9 @@ static PyObject* n_gather_strings( PyObject* self, PyObject* args )
                 indexes[idx] = (int)PyLong_AsLong(pyidx);
             }
             //
+            Py_BEGIN_ALLOW_THREADS
             rtn = tptr->gather_strings(indexes,count,false);
+            Py_END_ALLOW_THREADS
             delete indexes;
         }
         else
@@ -389,7 +441,9 @@ static PyObject* n_gather_strings( PyObject* self, PyObject* args )
             // assume device pointer
             int* indexes = (int*)PyLong_AsVoidPtr(pyidxs);
             unsigned int count = (unsigned int)PyLong_AsLong(PyTuple_GetItem(args,2));
+            Py_BEGIN_ALLOW_THREADS
             rtn = tptr->gather_strings(indexes,count);
+            Py_END_ALLOW_THREADS
         }
     }
     catch(const std::out_of_range& eor)
@@ -419,7 +473,9 @@ static PyObject* n_gather( PyObject* self, PyObject* args )
                 indexes[idx] = (int)PyLong_AsLong(pyidx);
             }
             //
+            Py_BEGIN_ALLOW_THREADS
             rtn = tptr->gather(indexes,count,false);
+            Py_END_ALLOW_THREADS
             delete indexes;
         }
         else
@@ -427,7 +483,9 @@ static PyObject* n_gather( PyObject* self, PyObject* args )
             // assume device pointer
             int* indexes = (int*)PyLong_AsVoidPtr(pyidxs);
             unsigned int count = (unsigned int)PyLong_AsLong(PyTuple_GetItem(args,2));
+            Py_BEGIN_ALLOW_THREADS
             rtn = tptr->gather(indexes,count);
+            Py_END_ALLOW_THREADS
         }
     }
     catch(const std::out_of_range& eor)
@@ -457,7 +515,9 @@ static PyObject* n_gather_and_remap( PyObject* self, PyObject* args )
                 indexes[idx] = (int)PyLong_AsLong(pyidx);
             }
             //
+            Py_BEGIN_ALLOW_THREADS
             rtn = tptr->gather_and_remap(indexes,count,false);
+            Py_END_ALLOW_THREADS
             delete indexes;
         }
         else
@@ -465,7 +525,9 @@ static PyObject* n_gather_and_remap( PyObject* self, PyObject* args )
             // assume device pointer
             int* indexes = (int*)PyLong_AsVoidPtr(pyidxs);
             unsigned int count = (unsigned int)PyLong_AsLong(PyTuple_GetItem(args,2));
+            Py_BEGIN_ALLOW_THREADS
             rtn = tptr->gather_and_remap(indexes,count);
+            Py_END_ALLOW_THREADS
         }
     }
     catch(const std::out_of_range& eor)
@@ -499,7 +561,10 @@ static PyObject* n_merge_category( PyObject* self, PyObject* args )
         Py_RETURN_NONE;
     }
 
-    NVCategory* rtn = tptr->merge_category(*cat2);
+    NVCategory* rtn = nullptr;
+    Py_BEGIN_ALLOW_THREADS
+    rtn = tptr->merge_category(*cat2);
+    Py_END_ALLOW_THREADS
     if( rtn )
         return PyLong_FromVoidPtr((void*)rtn);
     Py_RETURN_NONE;
@@ -527,7 +592,10 @@ static PyObject* n_merge_and_remap( PyObject* self, PyObject* args )
         Py_RETURN_NONE;
     }
 
-    NVCategory* rtn = tptr->merge_and_remap(*cat2);
+    NVCategory* rtn = nullptr;
+    Py_BEGIN_ALLOW_THREADS
+    rtn = tptr->merge_and_remap(*cat2);
+    Py_END_ALLOW_THREADS
     if( rtn )
         return PyLong_FromVoidPtr((void*)rtn);
     Py_RETURN_NONE;
@@ -555,7 +623,10 @@ static PyObject* n_add_keys( PyObject* self, PyObject* args )
         Py_RETURN_NONE;
     }
 
-    NVCategory* rtn = tptr->add_keys_and_remap(*strs);
+    NVCategory* rtn = nullptr;
+    Py_BEGIN_ALLOW_THREADS
+    rtn = tptr->add_keys_and_remap(*strs);
+    Py_END_ALLOW_THREADS
     if( rtn )
         return PyLong_FromVoidPtr((void*)rtn);
     Py_RETURN_NONE;
@@ -583,7 +654,10 @@ static PyObject* n_remove_keys( PyObject* self, PyObject* args )
         Py_RETURN_NONE;
     }
 
-    NVCategory* rtn = tptr->remove_keys_and_remap(*strs);
+    NVCategory* rtn = nullptr;
+    Py_BEGIN_ALLOW_THREADS
+    rtn = tptr->remove_keys_and_remap(*strs);
+    Py_END_ALLOW_THREADS
     if( rtn )
         return PyLong_FromVoidPtr((void*)rtn);
     Py_RETURN_NONE;
@@ -592,7 +666,10 @@ static PyObject* n_remove_keys( PyObject* self, PyObject* args )
 static PyObject* n_remove_unused_keys( PyObject* self, PyObject* args )
 {
     NVCategory* tptr = (NVCategory*)PyLong_AsVoidPtr(PyTuple_GetItem(args,0));
-    NVCategory* rtn = tptr->remove_unused_keys_and_remap();
+    NVCategory* rtn = nullptr;
+    Py_BEGIN_ALLOW_THREADS
+    rtn = tptr->remove_unused_keys_and_remap();
+    Py_END_ALLOW_THREADS
     if( rtn )
         return PyLong_FromVoidPtr((void*)rtn);
     Py_RETURN_NONE;
@@ -620,7 +697,10 @@ static PyObject* n_set_keys( PyObject* self, PyObject* args )
         Py_RETURN_NONE;
     }
 
-    NVCategory* rtn = tptr->set_keys_and_remap(*strs);
+    NVCategory* rtn = nullptr;
+    Py_BEGIN_ALLOW_THREADS
+    rtn = tptr->set_keys_and_remap(*strs);
+    Py_END_ALLOW_THREADS
     if( rtn )
         return PyLong_FromVoidPtr((void*)rtn);
     Py_RETURN_NONE;
@@ -661,4 +741,3 @@ PyMODINIT_FUNC PyInit_pyniNVCategory(void)
 {
     return PyModule_Create(&cModPyDem);
 }
-

--- a/python/cpp/pycategory.cpp
+++ b/python/cpp/pycategory.cpp
@@ -206,20 +206,14 @@ static PyObject* n_destroyCategory( PyObject* self, PyObject* args )
 static PyObject* n_size( PyObject* self, PyObject* args )
 {
     NVCategory* tptr = (NVCategory*)PyLong_AsVoidPtr(PyTuple_GetItem(args,0));
-    size_t count = 0;
-    Py_BEGIN_ALLOW_THREADS
-    count = tptr->size();
-    Py_END_ALLOW_THREADS
+    size_t count = tptr->size();
     return PyLong_FromLong(count);
 }
 
 static PyObject* n_keys_size( PyObject* self, PyObject* args )
 {
     NVCategory* tptr = (NVCategory*)PyLong_AsVoidPtr(PyTuple_GetItem(args,0));
-    size_t count = 0;
-    Py_BEGIN_ALLOW_THREADS
-    count = tptr->keys_size();
-    Py_END_ALLOW_THREADS
+    size_t count = tptr->keys_size();
     return PyLong_FromLong(count);
 }
 

--- a/python/cpp/pystrings.cpp
+++ b/python/cpp/pystrings.cpp
@@ -238,7 +238,7 @@ static PyObject* n_destroyStrings( PyObject* self, PyObject* args )
 {
     NVStrings* tptr = (NVStrings*)PyLong_AsVoidPtr(PyTuple_GetItem(args,0));
     Py_BEGIN_ALLOW_THREADS
-        NVStrings::destroy(tptr);
+    NVStrings::destroy(tptr);
     Py_END_ALLOW_THREADS
     return PyLong_FromLong(0);
 }
@@ -333,7 +333,7 @@ static PyObject* n_createFromNVStrings( PyObject* self, PyObject* args )
 
     NVStrings* thisptr = nullptr;
     Py_BEGIN_ALLOW_THREADS
-        thisptr = NVStrings::create_from_strings(strslist);
+    thisptr = NVStrings::create_from_strings(strslist);
     Py_END_ALLOW_THREADS
     return PyLong_FromVoidPtr((void*)thisptr);
 }
@@ -408,8 +408,8 @@ static PyObject* n_createFromOffsets( PyObject* self, PyObject* args )
     // create strings object from these buffers
     NVStrings* rtn = nullptr;
     Py_BEGIN_ALLOW_THREADS
-        rtn = NVStrings::create_from_offsets(sbuffer,scount,obuffer,
-                                                        nbuffer,ncount);
+    rtn = NVStrings::create_from_offsets(sbuffer,scount,obuffer,
+                                         nbuffer,ncount);
     Py_END_ALLOW_THREADS
 
     if( PyObject_CheckBuffer(pysbuf) )
@@ -813,7 +813,7 @@ static PyObject* n_create_offsets( PyObject* self, PyObject* args )
 
     // create strings object from these buffers
     Py_BEGIN_ALLOW_THREADS
-        tptr->create_offsets(sbuffer,obuffer,nbuffer,bdevmem);
+    tptr->create_offsets(sbuffer,obuffer,nbuffer,bdevmem);
     Py_END_ALLOW_THREADS
 
     if( PyObject_CheckBuffer(pysbuf) )
@@ -831,7 +831,7 @@ static PyObject* n_size( PyObject* self, PyObject* args )
     NVStrings* tptr = (NVStrings*)PyLong_AsVoidPtr(PyTuple_GetItem(args,0));
     unsigned int count = 0;
     Py_BEGIN_ALLOW_THREADS
-        count = tptr->size();
+    count = tptr->size();
     Py_END_ALLOW_THREADS
     return PyLong_FromLong(count);
 }
@@ -876,7 +876,7 @@ static PyObject* n_byte_count( PyObject* self, PyObject* args )
     bool bdevmem = (bool)PyObject_IsTrue(PyTuple_GetItem(args,2));
     size_t rtn = 0;
     Py_BEGIN_ALLOW_THREADS
-        rtn = tptr->byte_count(memptr,bdevmem);
+    rtn = tptr->byte_count(memptr,bdevmem);
     Py_END_ALLOW_THREADS
     return PyLong_FromLong((long)rtn);
 }
@@ -888,7 +888,7 @@ static PyObject* n_null_count( PyObject* self, PyObject* args )
     bool ben = (bool)PyObject_IsTrue(PyTuple_GetItem(args,1));
     unsigned int nulls = 0;
     Py_BEGIN_ALLOW_THREADS
-        nulls = tptr->get_nulls(0,ben,false);
+    nulls = tptr->get_nulls(0,ben,false);
     Py_END_ALLOW_THREADS
     return PyLong_FromLong((long)nulls);
 }
@@ -2168,10 +2168,10 @@ static PyObject* n_contains( PyObject* self, PyObject* args )
     {
         //Save thread state and release the GIL as we do not operate on PyObjects
         Py_BEGIN_ALLOW_THREADS
-            if( bregex )
-                rc = tptr->contains_re(str,devptr);
-            else
-                rc = tptr->contains(str,devptr);
+        if( bregex )
+            rc = tptr->contains_re(str,devptr);
+        else
+            rc = tptr->contains(str,devptr);
         //Restore thread state and acquire the GIL again.
         Py_END_ALLOW_THREADS
 
@@ -2186,10 +2186,10 @@ static PyObject* n_contains( PyObject* self, PyObject* args )
     bool* rtn = new bool[count];
 
     Py_BEGIN_ALLOW_THREADS
-        if( bregex )
-            rc = tptr->contains_re(str,rtn,false);
-        else
-            rc = tptr->contains(str,rtn,false);
+    if( bregex )
+        rc = tptr->contains_re(str,rtn,false);
+    else
+        rc = tptr->contains(str,rtn,false);
     Py_END_ALLOW_THREADS
 
     if( rc < 0 )
@@ -2629,7 +2629,7 @@ static PyObject* n_gather( PyObject* self, PyObject* args )
     try
     {
         Py_BEGIN_ALLOW_THREADS
-            rtn = tptr->gather(indexes,count,bdevmem);
+        rtn = tptr->gather(indexes,count,bdevmem);
         Py_END_ALLOW_THREADS
     }
     catch(const std::out_of_range& eor)

--- a/python/cpp/pystrings.cpp
+++ b/python/cpp/pystrings.cpp
@@ -1492,7 +1492,7 @@ static PyObject* n_cat( PyObject* self, PyObject* args )
         // this is just a join -- need to account for the other parms too
         NVStrings* rtn = nullptr;
         Py_BEGIN_ALLOW_THREADS
-        tptr->join(sep,narep);
+        rtn = tptr->join(sep,narep);
         Py_END_ALLOW_THREADS
         if( rtn )
             return PyLong_FromVoidPtr((void*)rtn);

--- a/python/cpp/pystrings.cpp
+++ b/python/cpp/pystrings.cpp
@@ -329,7 +329,10 @@ static PyObject* n_createFromNVStrings( PyObject* self, PyObject* args )
         Py_RETURN_NONE;
     }
 
-    NVStrings* thisptr = NVStrings::create_from_strings(strslist);
+    NVStrings* thisptr = nullptr;
+    Py_BEGIN_ALLOW_THREADS
+        thisptr = NVStrings::create_from_strings(strslist);
+    Py_END_ALLOW_THREADS
     return PyLong_FromVoidPtr((void*)thisptr);
 }
 
@@ -401,7 +404,11 @@ static PyObject* n_createFromOffsets( PyObject* self, PyObject* args )
     //printf(" ptrs=%p,%p,%p\n",sbuffer,obuffer,nbuffer);
     //printf(" scount=%d,ncount=%d\n",scount,ncount);
     // create strings object from these buffers
-    NVStrings* rtn = NVStrings::create_from_offsets(sbuffer,scount,obuffer,nbuffer,ncount);
+    NVStrings* rtn = nullptr;
+    Py_BEGIN_ALLOW_THREADS
+        rtn = NVStrings::create_from_offsets(sbuffer,scount,obuffer,
+                                                        nbuffer,ncount);
+    Py_END_ALLOW_THREADS
 
     if( PyObject_CheckBuffer(pysbuf) )
         PyBuffer_Release(&sbuf);
@@ -802,8 +809,16 @@ static PyObject* n_create_offsets( PyObject* self, PyObject* args )
     PyObject* pybmem = PyTuple_GetItem(args,4);
     bool bdevmem = (bool)PyObject_IsTrue(pybmem);
 
+    PyObject* tempPrint = PyUnicode_FromString("offset GIL release");
+    PyObject_Print(tempPrint, stdout, Py_PRINT_RAW);
+    Py_XDECREF(tempPrint);
     // create strings object from these buffers
-    tptr->create_offsets(sbuffer,obuffer,nbuffer,bdevmem);
+    Py_BEGIN_ALLOW_THREADS
+        tptr->create_offsets(sbuffer,obuffer,nbuffer,bdevmem);
+    Py_END_ALLOW_THREADS
+    tempPrint = PyUnicode_FromString("offset acquired GIL");
+    PyObject_Print(tempPrint, stdout, Py_PRINT_RAW);
+    Py_XDECREF(tempPrint);
 
     if( PyObject_CheckBuffer(pysbuf) )
         PyBuffer_Release(&sbuf);
@@ -818,7 +833,10 @@ static PyObject* n_create_offsets( PyObject* self, PyObject* args )
 static PyObject* n_size( PyObject* self, PyObject* args )
 {
     NVStrings* tptr = (NVStrings*)PyLong_AsVoidPtr(PyTuple_GetItem(args,0));
-    unsigned int count = tptr->size();
+    unsigned int count = 0;
+    Py_BEGIN_ALLOW_THREADS
+        count = tptr->size();
+    Py_END_ALLOW_THREADS
     return PyLong_FromLong(count);
 }
 
@@ -860,8 +878,10 @@ static PyObject* n_byte_count( PyObject* self, PyObject* args )
     NVStrings* tptr = (NVStrings*)PyLong_AsVoidPtr(PyTuple_GetItem(args,0));
     int* memptr = (int*)PyLong_AsVoidPtr(PyTuple_GetItem(args,1));
     bool bdevmem = (bool)PyObject_IsTrue(PyTuple_GetItem(args,2));
-
-    size_t rtn = tptr->byte_count(memptr,bdevmem);
+    size_t rtn = 0;
+    Py_BEGIN_ALLOW_THREADS
+        rtn = tptr->byte_count(memptr,bdevmem);
+    Py_END_ALLOW_THREADS
     return PyLong_FromLong((long)rtn);
 }
 
@@ -870,7 +890,10 @@ static PyObject* n_null_count( PyObject* self, PyObject* args )
 {
     NVStrings* tptr = (NVStrings*)PyLong_AsVoidPtr(PyTuple_GetItem(args,0));
     bool ben = (bool)PyObject_IsTrue(PyTuple_GetItem(args,1));
-    unsigned int nulls = tptr->get_nulls(0,ben,false);
+    unsigned int nulls = 0;
+    Py_BEGIN_ALLOW_THREADS
+        nulls = tptr->get_nulls(0,ben,false);
+    Py_END_ALLOW_THREADS
     return PyLong_FromLong((long)nulls);
 }
 

--- a/python/cpp/pystrings.cpp
+++ b/python/cpp/pystrings.cpp
@@ -270,7 +270,6 @@ static PyObject* n_createHostStrings( PyObject* self, PyObject* args )
     std::vector<char*> list(count);
     char** plist = list.data();
     std::vector<int> lens(count);
-    Py_BEGIN_ALLOW_THREADS
     size_t totalmem = tptr->byte_count(lens.data(),false);
     std::vector<char> buffer(totalmem+count,0); // null terminates each string
     char* pbuffer = buffer.data();
@@ -280,6 +279,7 @@ static PyObject* n_createHostStrings( PyObject* self, PyObject* args )
         plist[idx] = pbuffer + offset;
         offset += lens[idx]+1; // account for null-terminator; also nulls are -1
     }
+    Py_BEGIN_ALLOW_THREADS
     tptr->to_host(plist,0,count);
     Py_END_ALLOW_THREADS
     PyObject* ret = PyList_New(count);
@@ -2663,9 +2663,13 @@ static PyObject* n_match_strings( PyObject* self, PyObject* args )
     {
         Py_BEGIN_ALLOW_THREADS
         rc = tptr->match_strings(*strs,devptr);
-        if( cname.compare("list")==0 )
-            NVStrings::destroy(strs); // destroy it if we made it (above)
         Py_END_ALLOW_THREADS
+        if( cname.compare("list")==0 )
+        {
+            Py_BEGIN_ALLOW_THREADS
+            NVStrings::destroy(strs); // destroy it if we made it (above)
+            Py_END_ALLOW_THREADS
+        }
         if( rc < 0 )
             Py_RETURN_NONE;
         return PyLong_FromVoidPtr((void*)devptr);
@@ -2680,9 +2684,13 @@ static PyObject* n_match_strings( PyObject* self, PyObject* args )
     bool* rtn = new bool[count];
     Py_BEGIN_ALLOW_THREADS
     rc = tptr->match_strings(*strs,rtn,false);
-    if( cname.compare("list")==0 )
-        NVStrings::destroy(strs); // destroy it if we made it (above)
     Py_END_ALLOW_THREADS
+    if( cname.compare("list")==0 )
+    {
+        Py_BEGIN_ALLOW_THREADS
+        NVStrings::destroy(strs); // destroy it if we made it (above)
+        Py_END_ALLOW_THREADS
+    }
     if( rc < 0 )
     {
         delete rtn;

--- a/python/cpp/pystrings.cpp
+++ b/python/cpp/pystrings.cpp
@@ -237,7 +237,9 @@ static PyObject* n_createFromHostStrings( PyObject* self, PyObject* args )
 static PyObject* n_destroyStrings( PyObject* self, PyObject* args )
 {
     NVStrings* tptr = (NVStrings*)PyLong_AsVoidPtr(PyTuple_GetItem(args,0));
-    NVStrings::destroy(tptr);
+    Py_BEGIN_ALLOW_THREADS
+        NVStrings::destroy(tptr);
+    Py_END_ALLOW_THREADS
     return PyLong_FromLong(0);
 }
 

--- a/python/cpp/pystrings.cpp
+++ b/python/cpp/pystrings.cpp
@@ -2628,66 +2628,9 @@ static PyObject* n_gather( PyObject* self, PyObject* args )
     NVStrings* rtn = 0;
     try
     {
-<<<<<<< 2a42719bcb1a2d54e4f5999932f451b49af43f5a
         Py_BEGIN_ALLOW_THREADS
             rtn = tptr->gather(indexes,count,bdevmem);
         Py_END_ALLOW_THREADS
-=======
-        if( cname.compare("list")==0 )
-        {
-            unsigned int count = (unsigned int)PyList_Size(pyidxs);
-            int* indexes = new int[count];
-            for( unsigned int idx=0; idx < count; ++idx )
-            {
-                PyObject* pyidx = PyList_GetItem(pyidxs,idx);
-                indexes[idx] = (int)PyLong_AsLong(pyidx);
-            }
-            //
-            Py_BEGIN_ALLOW_THREADS
-                rtn = tptr->gather(indexes,count,false);
-                delete indexes;
-            Py_END_ALLOW_THREADS
-        }
-        else if( cname.compare("DeviceNDArray")==0 )
-        {
-            PyObject* pysize = PyObject_GetAttr(pyidxs,PyUnicode_FromString("alloc_size"));
-            PyObject* pydcp = PyObject_GetAttr(pyidxs,PyUnicode_FromString("device_ctypes_pointer"));
-            PyObject* pyptr = PyObject_GetAttr(pydcp,PyUnicode_FromString("value"));
-            unsigned int count = (unsigned int)(PyLong_AsLong(pysize)/sizeof(int));
-            int* indexes = 0;
-            if( pyptr != Py_None )
-                indexes = (int*)PyLong_AsVoidPtr(pyptr);
-            //printf("device-array: %p,%u\n",indexes,count);
-            Py_BEGIN_ALLOW_THREADS
-                rtn = tptr->gather(indexes,count);
-            Py_END_ALLOW_THREADS
-        }
-        else if( PyObject_CheckBuffer(pyidxs) )
-        {
-            Py_buffer pybuf;
-            PyObject_GetBuffer(pyidxs,&pybuf,PyBUF_SIMPLE);
-            int* indexes = (int*)pybuf.buf;
-            unsigned int count = (unsigned int)(pybuf.len/sizeof(int));
-            //printf("buffer: %p,%u\n",indexes,count);
-            Py_BEGIN_ALLOW_THREADS
-                rtn = tptr->gather(indexes,count,false);
-            Py_END_ALLOW_THREADS
-            PyBuffer_Release(&pybuf);
-        }
-        else if( cname.compare("int")==0 ) // device pointer directly
-        {                                  // for consistency with other methods
-            int* indexes = (int*)PyLong_AsVoidPtr(pyidxs);
-            unsigned int count = (unsigned int)PyLong_AsLong(PyTuple_GetItem(args,2));
-            Py_BEGIN_ALLOW_THREADS
-                rtn = tptr->gather(indexes,count);
-            Py_END_ALLOW_THREADS
-        }
-        else
-        {
-            //printf("%s\n",cname.c_str());
-            PyErr_Format(PyExc_TypeError,"nvstrings: unknown type %s",cname.c_str());
-        }
->>>>>>> Remove debug print statements
     }
     catch(const std::out_of_range& eor)
     {

--- a/python/cpp/pystrings.cpp
+++ b/python/cpp/pystrings.cpp
@@ -260,10 +260,7 @@ static PyObject* n_destroyStrings( PyObject* self, PyObject* args )
 static PyObject* n_createHostStrings( PyObject* self, PyObject* args )
 {
     NVStrings* tptr = (NVStrings*)PyLong_AsVoidPtr(PyTuple_GetItem(args,0));
-    unsigned int count = 0;
-    Py_BEGIN_ALLOW_THREADS
-    count = tptr->size();
-    Py_END_ALLOW_THREADS
+    unsigned int count = tptr->size();
     if( count==0 )
         return PyList_New(0);
 
@@ -893,10 +890,7 @@ static PyObject* n_create_offsets( PyObject* self, PyObject* args )
 static PyObject* n_size( PyObject* self, PyObject* args )
 {
     NVStrings* tptr = (NVStrings*)PyLong_AsVoidPtr(PyTuple_GetItem(args,0));
-    unsigned int count = 0;
-    Py_BEGIN_ALLOW_THREADS
-    count = tptr->size();
-    Py_END_ALLOW_THREADS
+    unsigned int count = tptr->size();
     return PyLong_FromLong(count);
 }
 
@@ -914,10 +908,7 @@ static PyObject* n_len( PyObject* self, PyObject* args )
     }
 
     // copy to host option
-    unsigned int count = 0;
-    Py_BEGIN_ALLOW_THREADS
-    count = tptr->size();
-    Py_END_ALLOW_THREADS
+    unsigned int count = tptr->size();
     PyObject* ret = PyList_New(count);
     if( count==0 )
         return ret;
@@ -1002,10 +993,7 @@ static PyObject* n_compare( PyObject* self, PyObject* args )
 {
     NVStrings* tptr = (NVStrings*)PyLong_AsVoidPtr(PyTuple_GetItem(args,0));
     const char* str = PyUnicode_AsUTF8(PyTuple_GetItem(args,1));
-    unsigned int count = 0;
-    Py_BEGIN_ALLOW_THREADS
-    count = tptr->size();
-    Py_END_ALLOW_THREADS
+    unsigned int count = tptr->size();
     PyObject* ret = PyList_New(count);
     if( count==0 )
         return ret;
@@ -1046,10 +1034,7 @@ static PyObject* n_compare( PyObject* self, PyObject* args )
 static PyObject* n_hash( PyObject* self, PyObject* args )
 {
     NVStrings* tptr = (NVStrings*)PyLong_AsVoidPtr(PyTuple_GetItem(args,0));
-    unsigned int count = 0;
-    Py_BEGIN_ALLOW_THREADS
-    count = tptr->size();
-    Py_END_ALLOW_THREADS
+    unsigned int count = tptr->size();
     PyObject* ret = PyList_New(count);
     if( count==0 )
         return ret;
@@ -1090,10 +1075,7 @@ static PyObject* n_hash( PyObject* self, PyObject* args )
 static PyObject* n_stoi( PyObject* self, PyObject* args )
 {
     NVStrings* tptr = (NVStrings*)PyLong_AsVoidPtr(PyTuple_GetItem(args,0));
-    unsigned int count = 0;
-    Py_BEGIN_ALLOW_THREADS
-    count = tptr->size();
-    Py_END_ALLOW_THREADS
+    unsigned int count = tptr->size();
     PyObject* ret = PyList_New(count);
     if( count==0 )
         return ret;
@@ -1135,10 +1117,7 @@ static PyObject* n_stoi( PyObject* self, PyObject* args )
 static PyObject* n_stol( PyObject* self, PyObject* args )
 {
     NVStrings* tptr = (NVStrings*)PyLong_AsVoidPtr(PyTuple_GetItem(args,0));
-    unsigned int count = 0;
-    Py_BEGIN_ALLOW_THREADS
-    count = tptr->size();
-    Py_END_ALLOW_THREADS
+    unsigned int count = tptr->size();
     PyObject* ret = PyList_New(count);
     if( count==0 )
         return ret;
@@ -1180,10 +1159,7 @@ static PyObject* n_stol( PyObject* self, PyObject* args )
 static PyObject* n_stof( PyObject* self, PyObject* args )
 {
     NVStrings* tptr = (NVStrings*)PyLong_AsVoidPtr(PyTuple_GetItem(args,0));
-    unsigned int count = 0;
-    Py_BEGIN_ALLOW_THREADS
-    count = tptr->size();
-    Py_END_ALLOW_THREADS
+    unsigned int count = tptr->size();
     PyObject* ret = PyList_New(count);
     if( count==0 )
         return ret;
@@ -1223,10 +1199,7 @@ static PyObject* n_stof( PyObject* self, PyObject* args )
 static PyObject* n_stod( PyObject* self, PyObject* args )
 {
     NVStrings* tptr = (NVStrings*)PyLong_AsVoidPtr(PyTuple_GetItem(args,0));
-    unsigned int count = 0;
-    Py_BEGIN_ALLOW_THREADS
-    count = tptr->size();
-    Py_END_ALLOW_THREADS
+    unsigned int count = tptr->size();
     PyObject* ret = PyList_New(count);
     if( count==0 )
         return ret;
@@ -1266,10 +1239,7 @@ static PyObject* n_stod( PyObject* self, PyObject* args )
 static PyObject* n_htoi( PyObject* self, PyObject* args )
 {
     NVStrings* tptr = (NVStrings*)PyLong_AsVoidPtr(PyTuple_GetItem(args,0));
-    unsigned int count = 0;
-    Py_BEGIN_ALLOW_THREADS
-    count = tptr->size();
-    Py_END_ALLOW_THREADS
+    unsigned int count = tptr->size();
     PyObject* ret = PyList_New(count);
     if( count==0 )
         return ret;
@@ -1311,10 +1281,7 @@ static PyObject* n_htoi( PyObject* self, PyObject* args )
 static PyObject* n_ip2int( PyObject* self, PyObject* args )
 {
     NVStrings* tptr = (NVStrings*)PyLong_AsVoidPtr(PyTuple_GetItem(args,0));
-    unsigned int count = 0;
-    Py_BEGIN_ALLOW_THREADS
-    count = tptr->size();
-    Py_END_ALLOW_THREADS
+    unsigned int count = tptr->size();
     PyObject* ret = PyList_New(count);
     if( count==0 )
         return ret;
@@ -1356,10 +1323,7 @@ static PyObject* n_ip2int( PyObject* self, PyObject* args )
 static PyObject* n_timestamp2int( PyObject* self, PyObject* args )
 {
     NVStrings* tptr = (NVStrings*)PyLong_AsVoidPtr(PyTuple_GetItem(args,0));
-    unsigned int count = 0;
-    Py_BEGIN_ALLOW_THREADS
-    count = tptr->size();
-    Py_END_ALLOW_THREADS
+    unsigned int count = tptr->size();
     PyObject* ret = PyList_New(count);
     if( count==0 )
         return ret;
@@ -1415,10 +1379,7 @@ static PyObject* n_timestamp2int( PyObject* self, PyObject* args )
 static PyObject* n_to_bools( PyObject* self, PyObject* args )
 {
     NVStrings* tptr = (NVStrings*)PyLong_AsVoidPtr(PyTuple_GetItem(args,0));
-    unsigned int count = 0;
-    Py_BEGIN_ALLOW_THREADS
-    count = tptr->size();
-    Py_END_ALLOW_THREADS
+    unsigned int count = tptr->size();
     PyObject* ret = PyList_New(count);
     if( count==0 )
         return ret;
@@ -1512,7 +1473,7 @@ static PyObject* n_cat( PyObject* self, PyObject* args )
             Py_RETURN_NONE;
         }
 
-        if( count != (int)tptr->size() ) //Consider releasing GIL here?
+        if( count != (int)tptr->size() )
         {
             PyErr_Format(PyExc_ValueError,"nvstrings.cat list size must match");
             Py_RETURN_NONE;
@@ -2107,10 +2068,7 @@ static PyObject* n_find( PyObject* self, PyObject* args )
         return PyLong_FromVoidPtr((void*)devptr);
     }
     // copy to host option
-    unsigned int count = 0;
-    Py_BEGIN_ALLOW_THREADS
-    count = tptr->size();
-    Py_END_ALLOW_THREADS
+    unsigned int count = tptr->size();
     PyObject* ret = PyList_New(count);
     if( count==0 )
         return ret;
@@ -2150,10 +2108,7 @@ static PyObject* n_find_from( PyObject* self, PyObject* args )
         return PyLong_FromVoidPtr((void*)devptr);
     }
     // copy to host option
-    unsigned int count = 0;
-    Py_BEGIN_ALLOW_THREADS
-    count = tptr->size();
-    Py_END_ALLOW_THREADS
+    unsigned int count = tptr->size();
     PyObject* ret = PyList_New(count);
     if( count==0 )
         return ret;
@@ -2187,10 +2142,7 @@ static PyObject* n_rfind( PyObject* self, PyObject* args )
     if( argEnd != Py_None )
         end = (int)PyLong_AsLong(argEnd);
     //
-    unsigned int count = 0;
-    Py_BEGIN_ALLOW_THREADS
-    count = tptr->size();
-    Py_END_ALLOW_THREADS
+    unsigned int count = tptr->size();
     //
     int* devptr = (int*)PyLong_AsVoidPtr(PyTuple_GetItem(args,4));
     if( devptr )
@@ -2285,10 +2237,7 @@ static PyObject* n_find_multiple( PyObject* self, PyObject* args )
         return PyLong_FromVoidPtr((void*)devptr);
     }
     // copy to host option
-    unsigned int rows = 0;
-    Py_BEGIN_ALLOW_THREADS
-    rows = tptr->size();
-    Py_END_ALLOW_THREADS
+    unsigned int rows = tptr->size();
     PyObject* ret = PyList_New(rows);
     if( rows==0 )
     {
@@ -2301,10 +2250,7 @@ static PyObject* n_find_multiple( PyObject* self, PyObject* args )
         return ret;
     }
     //
-    unsigned int columns = 0;
-    Py_BEGIN_ALLOW_THREADS
-    columns = strs->size();
-    Py_END_ALLOW_THREADS
+    unsigned int columns = strs->size();
     int* rtn = new int[rows*columns];
     Py_BEGIN_ALLOW_THREADS
     tptr->find_multiple(*strs,rtn,false);
@@ -2348,10 +2294,7 @@ static PyObject* n_index( PyObject* self, PyObject* args )
     if( argEnd != Py_None )
         end = (int)PyLong_AsLong(argEnd);
     //
-    unsigned int count = 0;
-    Py_BEGIN_ALLOW_THREADS
-    count = tptr->size();
-    Py_END_ALLOW_THREADS
+    unsigned int count = tptr->size();
     //
     int* devptr = (int*)PyLong_AsVoidPtr(PyTuple_GetItem(args,4));
     if( devptr )
@@ -2403,10 +2346,7 @@ static PyObject* n_rindex( PyObject* self, PyObject* args )
     if( argEnd != Py_None )
         end = (int)PyLong_AsLong(argEnd);
     //
-    unsigned int count = 0;
-    Py_BEGIN_ALLOW_THREADS
-    count = tptr->size();
-    Py_END_ALLOW_THREADS
+    unsigned int count = tptr->size();
     //
     int* devptr = (int*)PyLong_AsVoidPtr(PyTuple_GetItem(args,4));
     if( devptr )
@@ -2510,10 +2450,7 @@ static PyObject* n_contains( PyObject* self, PyObject* args )
         return PyLong_FromVoidPtr((void*)devptr);
     }
     // copy to host option
-    unsigned int count = 0;
-    Py_BEGIN_ALLOW_THREADS
-    count = tptr->size();
-    Py_END_ALLOW_THREADS
+    unsigned int count = tptr->size();
     if( count==0 )
         return PyList_New(0);
     bool* rtn = new bool[count];
@@ -2567,10 +2504,7 @@ static PyObject* n_match( PyObject* self, PyObject* args )
         return PyLong_FromVoidPtr((void*)devptr);
     }
     // copy to host option
-    unsigned int count = 0;
-    Py_BEGIN_ALLOW_THREADS
-    count = tptr->size();
-    Py_END_ALLOW_THREADS
+    unsigned int count = tptr->size();
     if( count==0 )
         return PyList_New(0);
     bool* rtn = new bool[count];
@@ -2675,10 +2609,7 @@ static PyObject* n_match_strings( PyObject* self, PyObject* args )
         return PyLong_FromVoidPtr((void*)devptr);
     }
     // copy to host option
-    unsigned int count = 0;
-    Py_BEGIN_ALLOW_THREADS
-    count = tptr->size();
-    Py_END_ALLOW_THREADS
+    unsigned int count = tptr->size();
     if( count==0 )
         return PyList_New(0);
     bool* rtn = new bool[count];
@@ -2717,10 +2648,7 @@ static PyObject* n_startswith( PyObject* self, PyObject* args )
         return PyLong_FromVoidPtr((void*)devptr);
     }
     // copy to host option
-    unsigned int count = 0;
-    Py_BEGIN_ALLOW_THREADS
-    count = tptr->size();
-    Py_END_ALLOW_THREADS
+    unsigned int count = tptr->size();
     PyObject* ret = PyList_New(count);
     if( count==0 )
         return ret;
@@ -2761,10 +2689,7 @@ static PyObject* n_endswith( PyObject* self, PyObject* args )
         return PyLong_FromVoidPtr((void*)devptr);
     }
     // copy to host option
-    unsigned int count = 0;
-    Py_BEGIN_ALLOW_THREADS
-    count = tptr->size();
-    Py_END_ALLOW_THREADS
+    unsigned int count = tptr->size();
     PyObject* ret = PyList_New(count);
     if( count==0 )
         return ret;
@@ -2808,10 +2733,7 @@ static PyObject* n_count( PyObject* self, PyObject* args )
         return PyLong_FromVoidPtr((void*)devptr);
     }
     // copy to host option
-    unsigned int count = 0;
-    Py_BEGIN_ALLOW_THREADS
-    count = tptr->size();
-    Py_END_ALLOW_THREADS
+    unsigned int count = tptr->size();
     if( count==0 )
         return PyList_New(0);
     int* rtn = new int[count];
@@ -2991,10 +2913,7 @@ static PyObject* n_order( PyObject* self, PyObject* args )
     }
 
     // copy to host option
-    unsigned int count = 0;
-    Py_BEGIN_ALLOW_THREADS
-    count = tptr->size();
-    Py_END_ALLOW_THREADS
+    unsigned int count = tptr->size();
     PyObject* ret = PyList_New(count);
     if( count==0 )
         return ret;
@@ -3173,10 +3092,7 @@ static PyObject* n_isalnum( PyObject* self, PyObject* args )
         return PyLong_FromVoidPtr((void*)devptr);
     }
     // copy to host option
-    unsigned int count = 0;
-    Py_BEGIN_ALLOW_THREADS
-    count = tptr->size();
-    Py_END_ALLOW_THREADS
+    unsigned int count = tptr->size();
     PyObject* ret = PyList_New(count);
     if( count==0 )
         return ret;
@@ -3215,10 +3131,7 @@ static PyObject* n_isalpha( PyObject* self, PyObject* args )
         return PyLong_FromVoidPtr((void*)devptr);
     }
     // copy to host option
-    unsigned int count = 0;
-    Py_BEGIN_ALLOW_THREADS
-    count = tptr->size();
-    Py_END_ALLOW_THREADS
+    unsigned int count = tptr->size();
     PyObject* ret = PyList_New(count);
     if( count==0 )
         return ret;
@@ -3257,10 +3170,7 @@ static PyObject* n_isdigit( PyObject* self, PyObject* args )
         return PyLong_FromVoidPtr((void*)devptr);
     }
     // copy to host option
-    unsigned int count = 0;
-    Py_BEGIN_ALLOW_THREADS
-    count = tptr->size();
-    Py_END_ALLOW_THREADS
+    unsigned int count = tptr->size();
     PyObject* ret = PyList_New(count);
     if( count==0 )
         return ret;
@@ -3299,10 +3209,7 @@ static PyObject* n_isspace( PyObject* self, PyObject* args )
         return PyLong_FromVoidPtr((void*)devptr);
     }
     // copy to host option
-    unsigned int count = 0;
-    Py_BEGIN_ALLOW_THREADS
-    count = tptr->size();
-    Py_END_ALLOW_THREADS
+    unsigned int count = tptr->size();
     PyObject* ret = PyList_New(count);
     if( count==0 )
         return ret;
@@ -3341,10 +3248,7 @@ static PyObject* n_isdecimal( PyObject* self, PyObject* args )
         return PyLong_FromVoidPtr((void*)devptr);
     }
     // copy to host option
-    unsigned int count = 0;
-    Py_BEGIN_ALLOW_THREADS
-    count = tptr->size();
-    Py_END_ALLOW_THREADS
+    unsigned int count = tptr->size();
     PyObject* ret = PyList_New(count);
     if( count==0 )
         return ret;
@@ -3383,10 +3287,7 @@ static PyObject* n_isnumeric( PyObject* self, PyObject* args )
         return PyLong_FromVoidPtr((void*)devptr);
     }
     // copy to host option
-    unsigned int count = 0;
-    Py_BEGIN_ALLOW_THREADS
-    count = tptr->size();
-    Py_END_ALLOW_THREADS
+    unsigned int count = tptr->size();
     PyObject* ret = PyList_New(count);
     if( count==0 )
         return ret;
@@ -3425,10 +3326,7 @@ static PyObject* n_islower( PyObject* self, PyObject* args )
         return PyLong_FromVoidPtr((void*)devptr);
     }
     // copy to host option
-    unsigned int count = 0;
-    Py_BEGIN_ALLOW_THREADS
-    count = tptr->size();
-    Py_END_ALLOW_THREADS
+    unsigned int count = tptr->size();
     PyObject* ret = PyList_New(count);
     if( count==0 )
         return ret;
@@ -3467,10 +3365,7 @@ static PyObject* n_isupper( PyObject* self, PyObject* args )
         return PyLong_FromVoidPtr((void*)devptr);
     }
     // copy to host option
-    unsigned int count = 0;
-    Py_BEGIN_ALLOW_THREADS
-    count = tptr->size();
-    Py_END_ALLOW_THREADS
+    unsigned int count = tptr->size();
     PyObject* ret = PyList_New(count);
     if( count==0 )
         return ret;

--- a/python/cpp/pytext.cpp
+++ b/python/cpp/pytext.cpp
@@ -112,10 +112,7 @@ static PyObject* n_token_count( PyObject* self, PyObject* args )
         return PyLong_FromLong((long)rtn);
     }
     //
-    unsigned int count = 0;
-    Py_BEGIN_ALLOW_THREADS
-    count = strs->size();
-    Py_END_ALLOW_THREADS
+    unsigned int count = strs->size();
     PyObject* ret = PyList_New(count);
     if( count==0 )
         return ret;
@@ -183,11 +180,8 @@ static PyObject* n_contains_strings( PyObject* self, PyObject* args )
         return PyLong_FromLong((long)rtn);
     }
     //
-    unsigned int rows = 0, columns = 0;
-    Py_BEGIN_ALLOW_THREADS
-    rows = strs->size();
-    columns = tgts->size();
-    Py_END_ALLOW_THREADS
+    unsigned int rows = strs->size();
+    unsigned int columns = tgts->size();
     PyObject* ret = PyList_New(rows);
     if( rows==0 )
     {
@@ -274,11 +268,8 @@ static PyObject* n_strings_counts( PyObject* self, PyObject* args )
         return PyLong_FromLong((long)rtn);
     }
     // or fill in python list with host memory
-    unsigned int rows = 0, columns = 0;
-    Py_BEGIN_ALLOW_THREADS
-    rows = strs->size();
-    columns = tgts->size();
-    Py_END_ALLOW_THREADS
+    unsigned int rows = strs->size();
+    unsigned int columns = tgts->size();;
     PyObject* ret = PyList_New(rows);
     if( rows==0 )
     {
@@ -325,10 +316,7 @@ static PyObject* n_edit_distance( PyObject* self, PyObject* args )
         Py_RETURN_NONE;
     }
 
-    unsigned int count = 0;
-    Py_BEGIN_ALLOW_THREADS
-    count = strs->size();
-    Py_END_ALLOW_THREADS
+    unsigned int count = strs->size();
     unsigned int* devptr = (unsigned int*)PyLong_AsVoidPtr(PyTuple_GetItem(args,2));
     std::string cname = pytgts->ob_type->tp_name;
     if( cname.compare("str")==0 )

--- a/python/cpp/pytext.cpp
+++ b/python/cpp/pytext.cpp
@@ -269,7 +269,7 @@ static PyObject* n_strings_counts( PyObject* self, PyObject* args )
     }
     // or fill in python list with host memory
     unsigned int rows = strs->size();
-    unsigned int columns = tgts->size();;
+    unsigned int columns = tgts->size();
     PyObject* ret = PyList_New(rows);
     if( rows==0 )
     {

--- a/python/cpp/pytext.cpp
+++ b/python/cpp/pytext.cpp
@@ -59,7 +59,10 @@ NVStrings* strings_from_list(PyObject* listObj)
         else
             list[idx] = PyUnicode_AsUTF8(pystr);
     }
-    NVStrings* strs = NVStrings::create_from_array(list,count);
+    NVStrings* strs = nullptr;
+    Py_BEGIN_ALLOW_THREADS
+    strs = NVStrings::create_from_array(list,count);
+    Py_END_ALLOW_THREADS
     delete list;
     return strs;
 }
@@ -78,7 +81,9 @@ static PyObject* n_unique_tokens( PyObject* self, PyObject* args )
     if( argDelim != Py_None )
         delimiter = PyUnicode_AsUTF8(argDelim);
 
+    Py_BEGIN_ALLOW_THREADS
     strs = NVText::unique_tokens(*strs,delimiter);
+    Py_END_ALLOW_THREADS
     if( strs==0 )
         Py_RETURN_NONE;
     return PyLong_FromVoidPtr((void*)strs);
@@ -100,16 +105,24 @@ static PyObject* n_token_count( PyObject* self, PyObject* args )
     unsigned int* devptr = (unsigned int*)PyLong_AsVoidPtr(PyTuple_GetItem(args,2));
     if( devptr )
     {
-        unsigned int rtn = NVText::token_count(*strs,delimiter,devptr);
+        unsigned int rtn = 0;
+        Py_BEGIN_ALLOW_THREADS
+        rtn = NVText::token_count(*strs,delimiter,devptr);
+        Py_END_ALLOW_THREADS
         return PyLong_FromLong((long)rtn);
     }
     //
-    unsigned int count = strs->size();
+    unsigned int count = 0;
+    Py_BEGIN_ALLOW_THREADS
+    count = strs->size();
+    Py_END_ALLOW_THREADS
     PyObject* ret = PyList_New(count);
     if( count==0 )
         return ret;
     unsigned int* rtn = new unsigned int[count];
+    Py_BEGIN_ALLOW_THREADS
     NVText::token_count(*strs,delimiter,rtn,false);
+    Py_END_ALLOW_THREADS
     for(unsigned int idx=0; idx < count; idx++)
         PyList_SetItem(ret, idx, PyLong_FromLong((long)rtn[idx]));
     delete rtn;
@@ -145,7 +158,11 @@ static PyObject* n_contains_strings( PyObject* self, PyObject* args )
     if( tgts->size()==0 )
     {
         if( cname.compare("list")==0 )
+        {
+            Py_BEGIN_ALLOW_THREADS
             NVStrings::destroy(tgts);
+            Py_END_ALLOW_THREADS
+        }
         PyErr_Format(PyExc_ValueError,"tgts argument is empty");
         Py_RETURN_NONE;
     }
@@ -153,23 +170,39 @@ static PyObject* n_contains_strings( PyObject* self, PyObject* args )
     bool* devptr = (bool*)PyLong_AsVoidPtr(PyTuple_GetItem(args,2));
     if( devptr )
     {
-        unsigned int rtn = NVText::contains_strings(*strs,*tgts,devptr);
+        unsigned int rtn = 0;
+        Py_BEGIN_ALLOW_THREADS
+        rtn = NVText::contains_strings(*strs,*tgts,devptr);
+        Py_END_ALLOW_THREADS
         if( cname.compare("list")==0 )
+        {
+            Py_BEGIN_ALLOW_THREADS
             NVStrings::destroy(tgts);
+            Py_END_ALLOW_THREADS
+        }
         return PyLong_FromLong((long)rtn);
     }
     //
-    unsigned int rows = strs->size();
-    unsigned int columns = tgts->size();
+    unsigned int rows = 0, columns = 0;
+    Py_BEGIN_ALLOW_THREADS
+    rows = strs->size();
+    columns = tgts->size();
+    Py_END_ALLOW_THREADS
     PyObject* ret = PyList_New(rows);
     if( rows==0 )
     {
         if( cname.compare("list")==0 )
+        {
+            Py_BEGIN_ALLOW_THREADS
             NVStrings::destroy(tgts);
+            Py_END_ALLOW_THREADS
+        }
         return ret;
     }
     bool* rtn = new bool[rows*columns];
+    Py_BEGIN_ALLOW_THREADS
     NVText::contains_strings(*strs,*tgts,rtn,false);
+    Py_END_ALLOW_THREADS
     for(unsigned int idx=0; idx < rows; idx++)
     {
         PyObject* row = PyList_New(columns);
@@ -179,7 +212,11 @@ static PyObject* n_contains_strings( PyObject* self, PyObject* args )
     }
     delete rtn;
     if( cname.compare("list")==0 )
+    {
+        Py_BEGIN_ALLOW_THREADS
         NVStrings::destroy(tgts);
+        Py_END_ALLOW_THREADS
+    }
     return ret;
 }
 
@@ -211,7 +248,11 @@ static PyObject* n_strings_counts( PyObject* self, PyObject* args )
     if( tgts->size()==0 )
     {
         if( cname.compare("list")==0 )
+        {
+            Py_BEGIN_ALLOW_THREADS
             NVStrings::destroy(tgts);
+            Py_END_ALLOW_THREADS
+        }
         PyErr_Format(PyExc_ValueError,"tgts argument is empty");
         Py_RETURN_NONE;
     }
@@ -220,23 +261,39 @@ static PyObject* n_strings_counts( PyObject* self, PyObject* args )
     unsigned int* devptr = (unsigned int*)PyLong_AsVoidPtr(PyTuple_GetItem(args,2));
     if( devptr )
     {
-        unsigned int rtn = NVText::strings_counts(*strs,*tgts,devptr);
+        unsigned int rtn = 0;
+        Py_BEGIN_ALLOW_THREADS
+        rtn = NVText::strings_counts(*strs,*tgts,devptr);
+        Py_END_ALLOW_THREADS
         if( cname.compare("list")==0 )
+        {
+            Py_BEGIN_ALLOW_THREADS
             NVStrings::destroy(tgts);
+            Py_END_ALLOW_THREADS
+        }
         return PyLong_FromLong((long)rtn);
     }
     // or fill in python list with host memory
-    unsigned int rows = strs->size();
-    unsigned int columns = tgts->size();
+    unsigned int rows = 0, columns = 0;
+    Py_BEGIN_ALLOW_THREADS
+    rows = strs->size();
+    columns = tgts->size();
+    Py_END_ALLOW_THREADS
     PyObject* ret = PyList_New(rows);
     if( rows==0 )
     {
         if( cname.compare("list")==0 )
+        {
+            Py_BEGIN_ALLOW_THREADS
             NVStrings::destroy(tgts);
+            Py_END_ALLOW_THREADS
+        }
         return ret;
     }
     unsigned int* rtn = new unsigned int[rows*columns];
+    Py_BEGIN_ALLOW_THREADS
     NVText::strings_counts(*strs,*tgts,rtn,false);
+    Py_END_ALLOW_THREADS
     for(unsigned int idx=0; idx < rows; idx++)
     {
         PyObject* row = PyList_New(columns);
@@ -246,7 +303,11 @@ static PyObject* n_strings_counts( PyObject* self, PyObject* args )
     }
     delete rtn;
     if( cname.compare("list")==0 )
+    {
+        Py_BEGIN_ALLOW_THREADS
         NVStrings::destroy(tgts);
+        Py_END_ALLOW_THREADS
+    }
     return ret;
 }
 
@@ -264,7 +325,10 @@ static PyObject* n_edit_distance( PyObject* self, PyObject* args )
         Py_RETURN_NONE;
     }
 
-    unsigned int count = strs->size();
+    unsigned int count = 0;
+    Py_BEGIN_ALLOW_THREADS
+    count = strs->size();
+    Py_END_ALLOW_THREADS
     unsigned int* devptr = (unsigned int*)PyLong_AsVoidPtr(PyTuple_GetItem(args,2));
     std::string cname = pytgts->ob_type->tp_name;
     if( cname.compare("str")==0 )
@@ -272,7 +336,9 @@ static PyObject* n_edit_distance( PyObject* self, PyObject* args )
         const char* tgt = PyUnicode_AsUTF8(pytgts);
         if( devptr )
         {
+            Py_BEGIN_ALLOW_THREADS
             NVText::edit_distance(NVText::levenshtein,*strs,tgt,devptr);
+            Py_END_ALLOW_THREADS
             Py_RETURN_NONE;
         }
         // or fill in python list with host memory
@@ -280,7 +346,9 @@ static PyObject* n_edit_distance( PyObject* self, PyObject* args )
         if( count==0 )
             return ret;
         std::vector<unsigned int> rtn(count);
+        Py_BEGIN_ALLOW_THREADS
         NVText::edit_distance(NVText::levenshtein,*strs,tgt,rtn.data(),false);
+        Py_END_ALLOW_THREADS
         for(unsigned int idx=0; idx < count; idx++)
             PyList_SetItem(ret, idx, PyLong_FromLong((long)rtn[idx]));
         return ret;
@@ -302,20 +370,32 @@ static PyObject* n_edit_distance( PyObject* self, PyObject* args )
     }
     if( devptr )
     {
+        Py_BEGIN_ALLOW_THREADS
         NVText::edit_distance(NVText::levenshtein,*strs,*tgts,devptr);
+        Py_END_ALLOW_THREADS
         if( cname.compare("list")==0 )
+        {
+            Py_BEGIN_ALLOW_THREADS
             NVStrings::destroy(tgts);
+            Py_END_ALLOW_THREADS
+        }
         Py_RETURN_NONE;
     }
     PyObject* ret = PyList_New(count);
     if( count==0 )
         return ret;
     std::vector<unsigned int> rtn(count);
+    Py_BEGIN_ALLOW_THREADS
     NVText::edit_distance(NVText::levenshtein,*strs,*tgts,rtn.data(),false);
+    Py_END_ALLOW_THREADS
     for(unsigned int idx=0; idx < count; idx++)
         PyList_SetItem(ret, idx, PyLong_FromLong((long)rtn[idx]));
     if( cname.compare("list")==0 )
+    {
+        Py_BEGIN_ALLOW_THREADS
         NVStrings::destroy(tgts);
+        Py_END_ALLOW_THREADS
+    }
     return ret;
 }
 
@@ -335,4 +415,3 @@ PyMODINIT_FUNC PyInit_pyniNVText(void)
 {
     return PyModule_Create(&cModPyDem);
 }
-


### PR DESCRIPTION
Closes #223 
Explicitly releases the GIL while making NvStrings calls at the cpp level and reacquire once the operation is performed. Uses the python c/cpp api macros `Py_BEGIN_ALLOW_THREADS` and `Py_END_ALLOW_THREADS`. 