### PR TITLE
fixed_find_documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Version jump from 0.3->0.7 is to align with other RAPIDS projects.
 - PR #221 Create separate conda packages for libnvstrings and nvstrings
 
 ## Bug Fixes
-
+- PR #248 Fixed docstring for index,rindex,find,rfind
 - PR #245 Fixed backref to continue replacing
 - PR #234 Added more type-checking to gather method
 - PR #226 Added data pre-check to create_from_index

--- a/python/nvstrings.py
+++ b/python/nvstrings.py
@@ -1647,10 +1647,10 @@ class nvstrings:
         sub : str
             String to find
         start : int
-            Beginning of section to replace.
-            Default is beginning of each string.
+            Beginning of section to search from.
+            Default is 0 (beginning of each string.)
         end : int
-            End of section to replace. Default is end of each string.
+            End of section to search. Default is end of each string.
         devptr : GPU memory pointer
             Optional device memory pointer to hold the results.
             Memory size must be able to hold at least size() of int32 values.
@@ -1675,10 +1675,10 @@ class nvstrings:
         sub : str
             String to find
         start : int
-            Beginning of section to replace.
-            Default is beginning of each string.
+            Beginning of section to search from.
+            Default is 0 (beginning of each string).
         end : int
-            End of section to replace. Default is end of each string.
+            End of section to search. Default is end of each string.
         devptr : GPU memory pointer
             Optional device memory pointer to hold the results.
             Memory size must be able to hold at least size() of int32 values.
@@ -1704,10 +1704,10 @@ class nvstrings:
         sub : str
             String to find
         start : int
-            Beginning of section to replace.
-            Default is beginning of each string.
+            Beginning of section to search from.
+            Default is 0 (beginning of each string).
         end : int
-            End of section to replace. Default is end of each string.
+            End of section to find. Default is end of each string.
         devptr : GPU memory pointer
             Optional device memory pointer to hold the results.
             Memory size must be able to hold at least size() of int32 values.
@@ -1771,10 +1771,10 @@ class nvstrings:
         sub : str
             String to find
         start : int
-            Beginning of section to replace.
-            Default is beginning of each string.
+            Beginning of section to find.
+            Default is 0(beginning of each string).
         end : int
-            End of section to replace. Default is end of each string.
+            End of section to find. Default is end of each string.
         devptr : GPU memory pointer
             Optional device memory pointer to hold the results.
 

--- a/python/nvstrings.py
+++ b/python/nvstrings.py
@@ -1648,7 +1648,7 @@ class nvstrings:
             String to find
         start : int
             Beginning of section to search from.
-            Default is 0 (beginning of each string.)
+            Default is 0 (beginning of each string).
         end : int
             End of section to search. Default is end of each string.
         devptr : GPU memory pointer


### PR DESCRIPTION
The previous doc strings for the following functions stated we replace instead of find. Fixed that.
* `index`
* `rindex`
* `find`
* `rfind`
