### PR TITLE
[REVIEW] Add cudatoolkit dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Version jump from 0.3->0.7 is to align with other RAPIDS projects.
 - PR #221 Create separate conda packages for libnvstrings and nvstrings
 - PR #247 Release Python GIl while calling underlying C++ API from python
 - PR #240 Initial suite of nvtext function Python unit tests
+- PR #275 Add cudatoolkit conda dependency
 
 ## Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ cuStrings can be installed with conda ([miniconda](https://conda.io/miniconda.ht
 ```bash
 # for CUDA 9.2
 conda install -c nvidia -c rapidsai -c numba -c conda-forge -c defaults \
-    nvstrings=0.4 python=3.6
+    nvstrings=0.4 python=3.6 cudatoolkit=9.2
 
 # or, for CUDA 10.0
-conda install -c nvidia/label/cuda10.0 -c rapidsai/label/cuda10.0 -c numba \
-    -c conda-forge -c defaults nvstrings=0.4 python=3.6
+conda install -c nvidia -c rapidsai -c numba -c conda-forge -c defaults \
+    nvstrings=0.4 python=3.6 cudatoolkit=10.0
 ```
 
 We also provide [nightly conda packages](https://anaconda.org/rapidsai-nightly) built from the tip of our latest development branch.

--- a/conda/environments/builddocs_py36.yml
+++ b/conda/environments/builddocs_py36.yml
@@ -13,5 +13,6 @@ dependencies:
 - ipython
 - recommonmark
 - pandoc=<2.0.0
+- cudatoolkit=9.2
 - pip:
   - sphinx-markdown-tables

--- a/conda/recipes/libcustrings/meta.yaml
+++ b/conda/recipes/libcustrings/meta.yaml
@@ -27,6 +27,8 @@ requirements:
   host:
     - librmm 0.7.*
     - cudatoolkit {{ cuda_version }}.*
+  run:
+    - {{ pin_compatible('cudatoolkit', max_pin='x.x') }}
 
 test:
   commands:

--- a/conda/recipes/libcustrings/meta.yaml
+++ b/conda/recipes/libcustrings/meta.yaml
@@ -2,7 +2,7 @@
 
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').lstrip('v') %}
 {% set git_revision_count=environ.get('GIT_DESCRIBE_NUMBER', 0) %}
-{% set cuda_version='.'.join(environ.get('CUDA_VERSION', 'unknown').split('.')[:2]) %}
+{% set cuda_version='.'.join(environ.get('CUDA_VERSION', '9.2').split('.')[:2]) %}
 package:
   name: libnvstrings
   version: {{ version }}
@@ -26,6 +26,7 @@ requirements:
     - cmake >=3.12
   host:
     - librmm 0.7.*
+    - cudatoolkit {{ cuda_version }}.*
 
 test:
   commands:


### PR DESCRIPTION
Refs conda-forge/conda-forge.github.io#687

This is to bring our conda packages in line with the community effort above and remove our current use of labels.