### PR TITLE
[REVIEW] Use latest tag in update-version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Version jump from 0.3->0.7 is to align with other RAPIDS projects.
 - PR #247 Release Python GIl while calling underlying C++ API from python
 - PR #240 Initial suite of nvtext function Python unit tests
 - PR #275 Add cudatoolkit conda dependency
+- PR #291 Use latest release version in update-version CI script
 
 ## Bug Fixes
 

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -13,7 +13,7 @@ set -e
 RELEASE_TYPE=$1
 
 # Get current version and calculate next versions
-CURRENT_TAG=`git describe --abbrev=0 --tags | tr -d 'v'`
+CURRENT_TAG=`git tag | grep -xE 'v[0-9\.]+' | sort --version-sort | tail -n 1 | tr -d 'v'`
 CURRENT_MAJOR=`echo $CURRENT_TAG | awk '{split($0, a, "."); print a[1]}'`
 CURRENT_MINOR=`echo $CURRENT_TAG | awk '{split($0, a, "."); print a[2]}'`
 CURRENT_PATCH=`echo $CURRENT_TAG | awk '{split($0, a, "."); print a[3]}'`
@@ -38,8 +38,6 @@ else
   exit 1
 fi
 
-# Move to root of repo
-cd ../..
 echo "Preparing '$RELEASE_TYPE' release [$CURRENT_TAG -> $NEXT_FULL_TAG]"
 
 # Inplace sed replace; workaround for Linux and Mac
@@ -48,3 +46,8 @@ function sed_runner() {
 }
 
 sed_runner 's/'"NVStrings VERSION .* LANGUAGES"'/'"NVStrings VERSION ${NEXT_FULL_TAG} LANGUAGES"'/g' cpp/CMakeLists.txt
+sed_runner 's/'"pyniNVStrings VERSION .* LANGUAGES"'/'"pyniNVStrings VERSION ${NEXT_FULL_TAG} LANGUAGES"'/g' python/cpp/CMakeLists.txt
+sed_runner 's/'"PROJECT_NUMBER         = .*"'/'"PROJECT_NUMBER         = ${NEXT_SHORT_TAG}"'/g' cpp/doxygen/Doxyfile
+
+sed_runner 's/version = .*/version = '"'${NEXT_SHORT_TAG}'"'/g' docs/source/conf.py
+sed_runner 's/release = .*/release = '"'${NEXT_FULL_TAG}'"'/g' docs/source/conf.py


### PR DESCRIPTION
Change update-version script to ignore dev/alpha/rc versions and use only the latest version

Also updated where changes are made