### PR TITLE
[REVIEW] Updated memsize() to include pointer memory too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - PR #357 Improved error checking on memory allocates
 - PR #358 Added improved hash algorithm to reduce collisions
 - PR #369 Reconfigure C++ source directory structure
+- PR #370 Updated memsize() to include pointer memory too
 
 ## Bug Fixes
 

--- a/cpp/include/NVStrings.h
+++ b/cpp/include/NVStrings.h
@@ -53,7 +53,7 @@ class NVStrings
     NVStrings();
     NVStrings(unsigned int count);
     NVStrings(const NVStrings&);
-    NVStrings& operator=(const NVStrings&);
+    NVStrings& operator=(const NVStrings&) = delete;
     ~NVStrings();
 
 public:

--- a/cpp/src/strings/NVStrings.cu
+++ b/cpp/src/strings/NVStrings.cu
@@ -54,13 +54,13 @@ NVStrings::NVStrings()
 
 NVStrings::NVStrings(const NVStrings& strsIn)
 {
-    NVStrings& strs = (NVStrings&)strsIn;
-    unsigned int count = strs.size();
+    //NVStrings& strs = (NVStrings&)strsIn;
+    unsigned int count = strsIn.size();
     pImpl = new NVStringsImpl(count);
     if( count )
     {
-        std::vector<NVStrings*> strslist;
-        strslist.push_back(&strs);
+        std::vector<NVStringsImpl*> strslist;
+        strslist.push_back(strsIn.pImpl);
         NVStrings_copy_strings(pImpl,strslist);
     }
 }
@@ -68,13 +68,13 @@ NVStrings::NVStrings(const NVStrings& strsIn)
 NVStrings& NVStrings::operator=(const NVStrings& strsIn)
 {
     delete pImpl;
-    NVStrings& strs = (NVStrings&)strsIn;
-    unsigned int count = strs.size();
+    //NVStrings& strs = (NVStrings&)strsIn;
+    unsigned int count = strsIn.size();
     pImpl = new NVStringsImpl(count);
     if( count )
     {
-        std::vector<NVStrings*> strslist;
-        strslist.push_back(&strs);
+        std::vector<NVStringsImpl*> strslist;
+        strslist.push_back(strsIn.pImpl);
         NVStrings_copy_strings(pImpl,strslist);
     }
     return *this;
@@ -133,7 +133,12 @@ NVStrings* NVStrings::create_from_strings( std::vector<NVStrings*> strs )
         count += (*itr)->size();
     NVStrings* rtn = new NVStrings(count);
     if( count )
-        NVStrings_copy_strings(rtn->pImpl,strs);
+    {
+        std::vector<NVStringsImpl*> impls;
+        for( auto itr=strs.begin(); itr!=strs.end(); itr++ )
+            impls.push_back( (*itr)->pImpl );
+        NVStrings_copy_strings(rtn->pImpl,impls);
+    }
     return rtn;
 }
 
@@ -173,7 +178,7 @@ void NVStrings::destroy(NVStrings* inst)
 
 size_t NVStrings::memsize() const
 {
-    return pImpl->bufferSize;
+    return pImpl->getMemorySize() + pImpl->getPointerSize();
 }
 
 NVStrings* NVStrings::copy()
@@ -182,8 +187,8 @@ NVStrings* NVStrings::copy()
     NVStrings* rtn = new NVStrings(count);
     if( count )
     {
-        std::vector<NVStrings*> strslist;
-        strslist.push_back(this);
+        std::vector<NVStringsImpl*> strslist;
+        strslist.push_back(pImpl);
         NVStrings_copy_strings(rtn->pImpl,strslist);
     }
     return rtn;
@@ -601,7 +606,7 @@ unsigned int NVStrings::get_nulls( unsigned int* array, bool emptyIsNull, bool d
 // number of strings in this instance
 unsigned int NVStrings::size() const
 {
-    return (unsigned int)pImpl->pList->size();
+    return pImpl->getCount();
 }
 
 struct statistics_attrs

--- a/cpp/src/strings/NVStrings.cu
+++ b/cpp/src/strings/NVStrings.cu
@@ -64,20 +64,6 @@ NVStrings::NVStrings(const NVStrings& strs)
     }
 }
 
-NVStrings& NVStrings::operator=(const NVStrings& strs)
-{
-    delete pImpl;
-    unsigned int count = strs.size();
-    pImpl = new NVStringsImpl(count);
-    if( count )
-    {
-        std::vector<NVStringsImpl*> strslist;
-        strslist.push_back(strs.pImpl);
-        NVStrings_copy_strings(pImpl,strslist);
-    }
-    return *this;
-}
-
 NVStrings::~NVStrings()
 {
     delete pImpl;

--- a/cpp/src/strings/NVStrings.cu
+++ b/cpp/src/strings/NVStrings.cu
@@ -52,29 +52,27 @@ NVStrings::NVStrings()
     pImpl = new NVStringsImpl(0);
 }
 
-NVStrings::NVStrings(const NVStrings& strsIn)
+NVStrings::NVStrings(const NVStrings& strs)
 {
-    //NVStrings& strs = (NVStrings&)strsIn;
-    unsigned int count = strsIn.size();
+    unsigned int count = strs.size();
     pImpl = new NVStringsImpl(count);
     if( count )
     {
         std::vector<NVStringsImpl*> strslist;
-        strslist.push_back(strsIn.pImpl);
+        strslist.push_back(strs.pImpl);
         NVStrings_copy_strings(pImpl,strslist);
     }
 }
 
-NVStrings& NVStrings::operator=(const NVStrings& strsIn)
+NVStrings& NVStrings::operator=(const NVStrings& strs)
 {
     delete pImpl;
-    //NVStrings& strs = (NVStrings&)strsIn;
-    unsigned int count = strsIn.size();
+    unsigned int count = strs.size();
     pImpl = new NVStringsImpl(count);
     if( count )
     {
         std::vector<NVStringsImpl*> strslist;
-        strslist.push_back(strsIn.pImpl);
+        strslist.push_back(strs.pImpl);
         NVStrings_copy_strings(pImpl,strslist);
     }
     return *this;

--- a/cpp/src/strings/NVStringsImpl.h
+++ b/cpp/src/strings/NVStringsImpl.h
@@ -39,8 +39,10 @@ public:
     char* createMemoryFor( size_t* d_lengths );
 
     inline custring_view_array getStringsPtr()      { return pList->data().get(); }
+    inline unsigned int getCount() { return (unsigned int)pList->size(); }
     inline char* getMemoryPtr()    { return memoryBuffer; }
     inline size_t getMemorySize()  { return bufferSize;  }
+    inline size_t getPointerSize() { return pList->size()*sizeof(custring_view*); }
     inline cudaStream_t getStream()    { return stream_id;  }
     inline void setMemoryBuffer( void* ptr, size_t memSize )
     {
@@ -65,5 +67,5 @@ int NVStrings_init_from_strings(NVStringsImpl* pImpl, const char** strs, unsigne
 int NVStrings_init_from_indexes( NVStringsImpl* pImpl, std::pair<const char*,size_t>* indexes, unsigned int count, bool bdevmem, NVStrings::sorttype stype );
 int NVStrings_init_from_offsets( NVStringsImpl* pImpl, const char* strs, int count, const int* offsets, const unsigned char* bitmask, int nulls );
 int NVStrings_init_from_device_offsets( NVStringsImpl* pImpl, const char* strs, int count, const int* offsets, const unsigned char* bitmask, int nulls );
-int NVStrings_copy_strings( NVStringsImpl* pImpl, std::vector<NVStrings*>& strslist );
+int NVStrings_copy_strings( NVStringsImpl* pImpl, std::vector<NVStringsImpl*>& strslist );
 int NVStrings_fixup_pointers( NVStringsImpl* pImpl, char* baseaddr );

--- a/cpp/src/strings/datetime.cu
+++ b/cpp/src/strings/datetime.cu
@@ -138,9 +138,9 @@ struct DTFormatCompiler
             template_string.append(ch,flen);
         }
         // create in device memory
-        size_t memsize = items.size() * sizeof(DTFormatItem);
-        d_items = reinterpret_cast<DTFormatItem*>(device_alloc<char>(memsize,0));
-        CUDA_TRY( cudaMemcpyAsync(d_items, items.data(), memsize, cudaMemcpyHostToDevice))
+        size_t buffer_size = items.size() * sizeof(DTFormatItem);
+        d_items = reinterpret_cast<DTFormatItem*>(device_alloc<char>(buffer_size,0));
+        CUDA_TRY( cudaMemcpyAsync(d_items, items.data(), buffer_size, cudaMemcpyHostToDevice))
         DTProgram hprog{items.size(),d_items};
         d_prog = reinterpret_cast<DTProgram*>(device_alloc<char>(sizeof(DTProgram),0));
         CUDA_TRY( cudaMemcpyAsync(d_prog,&hprog,sizeof(DTProgram),cudaMemcpyHostToDevice))
@@ -149,12 +149,6 @@ struct DTFormatCompiler
 
     // call valid only after compile
     size_t string_length() { return template_string.size(); }
-    //{
-    //    size_t size = 0;
-    //    for( size_t idx=0; idx < items.size(); ++idx )
-    //        size += items[idx].length;
-    //    return size;
-    //}
     const char* string_template() { return template_string.c_str(); }
 
     size_t size() { return items.size(); }


### PR DESCRIPTION
This is to support #362 
Previously this method only returned the string device memory.
It now includes the offset/pointer device memory as well.