### PR TITLE
[REVIEW] Properly catch exception in `gather_strings`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 *.a
 *.o
 *.so
+__pycache__
+*.pytest_cache
 ##
 cpp/build/
 cpp/doxygen/html/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ## Bug Fixes
 
 - PR #353 Fixed sizer calculation for multiple replaces
+- PR #373 Properly catch/throw exceptions raised by `gather_strings`
 
 
 # cuStrings/nvStrings 0.8.0 (27 June 2019)

--- a/python/cpp/pycategory.cpp
+++ b/python/cpp/pycategory.cpp
@@ -589,37 +589,53 @@ static PyObject* n_gather( PyObject* self, PyObject* args )
     PyObject* pyidxs = PyTuple_GetItem(args,1);
     std::string cname = pyidxs->ob_type->tp_name;
     NVCategory* rtn = 0;
-    try
+    std::string message;
+
+    if( cname.compare("list")==0 )
     {
-        if( cname.compare("list")==0 )
+        unsigned int count = (unsigned int)PyList_Size(pyidxs);
+        int* indexes = new int[count];
+        for( unsigned int idx=0; idx < count; ++idx )
         {
-            unsigned int count = (unsigned int)PyList_Size(pyidxs);
-            int* indexes = new int[count];
-            for( unsigned int idx=0; idx < count; ++idx )
-            {
-                PyObject* pyidx = PyList_GetItem(pyidxs,idx);
-                indexes[idx] = (int)PyLong_AsLong(pyidx);
-            }
-            //
-            Py_BEGIN_ALLOW_THREADS
+            PyObject* pyidx = PyList_GetItem(pyidxs,idx);
+            indexes[idx] = (int)PyLong_AsLong(pyidx);
+        }
+        //
+        Py_BEGIN_ALLOW_THREADS
+        try
+        {
             rtn = cat->gather(indexes,count,false);
-            Py_END_ALLOW_THREADS
-            delete indexes;
         }
-        else
+        catch(const std::out_of_range& eor)
         {
-            // assume device pointer
-            int* indexes = (int*)PyLong_AsVoidPtr(pyidxs);
-            unsigned int count = (unsigned int)PyLong_AsLong(PyTuple_GetItem(args,2));
-            Py_BEGIN_ALLOW_THREADS
-            rtn = cat->gather(indexes,count);
-            Py_END_ALLOW_THREADS
+            std::ostringstream errmsg;
+            errmsg << "one or more indexes out of range [0:" << cat->keys_size() << ")";
+            message = errmsg.str();
         }
+        Py_END_ALLOW_THREADS
+        delete indexes;
     }
-    catch(const std::out_of_range& eor)
+    else
     {
-        PyErr_Format(PyExc_IndexError,"one or more indexes out of range [0:%u)",cat->keys_size());
+        // assume device pointer
+        int* indexes = (int*)PyLong_AsVoidPtr(pyidxs);
+        unsigned int count = (unsigned int)PyLong_AsLong(PyTuple_GetItem(args,2));
+        Py_BEGIN_ALLOW_THREADS
+        try
+        {
+            rtn = cat->gather(indexes,count);
+        }
+        catch(const std::out_of_range& eor)
+        {
+            std::ostringstream errmsg;
+            errmsg << "one or more indexes out of range [0:" << cat->keys_size() << ")";
+            message = errmsg.str();
+        }
+        Py_END_ALLOW_THREADS
     }
+
+    if( !message.empty() )
+        PyErr_Format(PyExc_IndexError,message.c_str());
     if( rtn )
         return PyLong_FromVoidPtr((void*)rtn);
     Py_RETURN_NONE;
@@ -635,37 +651,53 @@ static PyObject* n_gather_and_remap( PyObject* self, PyObject* args )
     PyObject* pyidxs = PyTuple_GetItem(args,1);
     std::string cname = pyidxs->ob_type->tp_name;
     NVCategory* rtn = 0;
-    try
+    std::string message;
+
+    if( cname.compare("list")==0 )
     {
-        if( cname.compare("list")==0 )
+        unsigned int count = (unsigned int)PyList_Size(pyidxs);
+        int* indexes = new int[count];
+        for( unsigned int idx=0; idx < count; ++idx )
         {
-            unsigned int count = (unsigned int)PyList_Size(pyidxs);
-            int* indexes = new int[count];
-            for( unsigned int idx=0; idx < count; ++idx )
-            {
-                PyObject* pyidx = PyList_GetItem(pyidxs,idx);
-                indexes[idx] = (int)PyLong_AsLong(pyidx);
-            }
-            //
-            Py_BEGIN_ALLOW_THREADS
+            PyObject* pyidx = PyList_GetItem(pyidxs,idx);
+            indexes[idx] = (int)PyLong_AsLong(pyidx);
+        }
+        //
+        Py_BEGIN_ALLOW_THREADS
+        try
+        {
             rtn = cat->gather_and_remap(indexes,count,false);
-            Py_END_ALLOW_THREADS
-            delete indexes;
         }
-        else
+        catch(const std::out_of_range& eor)
         {
-            // assume device pointer
-            int* indexes = (int*)PyLong_AsVoidPtr(pyidxs);
-            unsigned int count = (unsigned int)PyLong_AsLong(PyTuple_GetItem(args,2));
-            Py_BEGIN_ALLOW_THREADS
-            rtn = cat->gather_and_remap(indexes,count);
-            Py_END_ALLOW_THREADS
+            std::ostringstream errmsg;
+            errmsg << "one or more indexes out of range [0:" << cat->keys_size() << ")";
+            message = errmsg.str();
         }
+        Py_END_ALLOW_THREADS
+        delete indexes;
     }
-    catch(const std::out_of_range& eor)
+    else
     {
-        PyErr_Format(PyExc_IndexError,"one or more indexes out of range [0:%u)",cat->keys_size());
+        // assume device pointer
+        int* indexes = (int*)PyLong_AsVoidPtr(pyidxs);
+        unsigned int count = (unsigned int)PyLong_AsLong(PyTuple_GetItem(args,2));
+        Py_BEGIN_ALLOW_THREADS
+        try
+        {
+            rtn = cat->gather_and_remap(indexes,count);
+        }
+        catch(const std::out_of_range& eor)
+        {
+            std::ostringstream errmsg;
+            errmsg << "one or more indexes out of range [0:" << cat->keys_size() << ")";
+            message = errmsg.str();
+        }
+        Py_END_ALLOW_THREADS
     }
+
+    if( !message.empty() )
+        PyErr_Format(PyExc_IndexError,message.c_str());
     if( rtn )
         return PyLong_FromVoidPtr((void*)rtn);
     Py_RETURN_NONE;

--- a/python/cpp/pycategory.cpp
+++ b/python/cpp/pycategory.cpp
@@ -538,8 +538,8 @@ static PyObject* n_gather_strings( PyObject* self, PyObject* args )
             errmsg << "one or more indexes out of range [0:" << cat->keys_size() << ")";
             message = errmsg.str();
         }
-        delete indexes;
         Py_END_ALLOW_THREADS
+        delete indexes;
     }
     else
     {

--- a/python/cpp/pycategory.cpp
+++ b/python/cpp/pycategory.cpp
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <exception>
 #include <stdexcept>
+#include <sstream>
 #include <nvstrings/NVCategory.h>
 #include <nvstrings/NVStrings.h>
 #include <nvstrings/numeric_category.h>
@@ -516,37 +517,51 @@ static PyObject* n_gather_strings( PyObject* self, PyObject* args )
     PyObject* pyidxs = PyTuple_GetItem(args,1);
     std::string cname = pyidxs->ob_type->tp_name;
     NVStrings* rtn = 0;
-    try
+    std::string message;
+    if( cname.compare("list")==0 )
     {
-        if( cname.compare("list")==0 )
+        unsigned int count = (unsigned int)PyList_Size(pyidxs);
+        int* indexes = new int[count];
+        for( unsigned int idx=0; idx < count; ++idx )
         {
-            unsigned int count = (unsigned int)PyList_Size(pyidxs);
-            int* indexes = new int[count];
-            for( unsigned int idx=0; idx < count; ++idx )
-            {
-                PyObject* pyidx = PyList_GetItem(pyidxs,idx);
-                indexes[idx] = (int)PyLong_AsLong(pyidx);
-            }
-            //
-            Py_BEGIN_ALLOW_THREADS
+            PyObject* pyidx = PyList_GetItem(pyidxs,idx);
+            indexes[idx] = (int)PyLong_AsLong(pyidx);
+        }
+        Py_BEGIN_ALLOW_THREADS
+        try
+        {
             rtn = cat->gather_strings(indexes,count,false);
-            Py_END_ALLOW_THREADS
-            delete indexes;
         }
-        else
+        catch(const std::out_of_range& eor)
         {
-            // assume device pointer
-            int* indexes = (int*)PyLong_AsVoidPtr(pyidxs);
-            unsigned int count = (unsigned int)PyLong_AsLong(PyTuple_GetItem(args,2));
-            Py_BEGIN_ALLOW_THREADS
-            rtn = cat->gather_strings(indexes,count);
-            Py_END_ALLOW_THREADS
+            std::ostringstream errmsg;
+            errmsg << "one or more indexes out of range [0:" << cat->keys_size() << ")";
+            message = errmsg.str();
         }
+        delete indexes;
+        Py_END_ALLOW_THREADS
     }
-    catch(const std::out_of_range& eor)
+    else
     {
-        PyErr_Format(PyExc_IndexError,"one or more indexes out of range [0:%u)",cat->keys_size());
+        // assume device pointer
+        int* indexes = (int*)PyLong_AsVoidPtr(pyidxs);
+        unsigned int count = (unsigned int)PyLong_AsLong(PyTuple_GetItem(args,2));
+        Py_BEGIN_ALLOW_THREADS
+        try
+        {
+            rtn = cat->gather_strings(indexes,count);
+        }
+        catch(const std::out_of_range& eor)
+        {
+            std::ostringstream errmsg;
+            errmsg << "one or more indexes out of range [0:" << cat->keys_size() << ")";
+            message = errmsg.str();
+        }
+        Py_END_ALLOW_THREADS
     }
+
+    if( !message.empty() )
+        PyErr_Format(PyExc_IndexError,message.c_str());
     if( rtn )
         return PyLong_FromVoidPtr((void*)rtn);
     Py_RETURN_NONE;

--- a/python/tests/test_category.py
+++ b/python/tests/test_category.py
@@ -103,13 +103,22 @@ def test_gather_strings():
     assert_eq(got, expected)
 
 
-def test_gather_strings_exception():
+@pytest.mark.parametrize(
+    "func",
+    [
+        lambda cat, indexes: cat.gather_strings(indexes),
+        lambda cat, indexes: cat.gather(indexes),
+        lambda cat, indexes: cat.gather_and_remap(indexes),
+    ],
+)
+def test_gather_index_exception(func):
     strs = nvstrings.to_device(
         ["eee", "aaa", "eee", "ddd", "ccc", "ccc", "ccc", "eee", "aaa"]
     )
     cat = nvcategory.from_strings(strs)
+    indexes = [0, 2, 0, 4]
     with pytest.raises(Exception):
-        cat.gather_strings([0, 2, 0, 4])
+        func(cat, indexes)
 
 
 def test_remove_strings():

--- a/python/tests/test_category.py
+++ b/python/tests/test_category.py
@@ -4,13 +4,15 @@ import nvstrings
 import nvcategory
 
 import numpy as np
+import pytest
 
 from utils import assert_eq
 
 
 def test_size():
     strs = nvstrings.to_device(
-        ["eee", "aaa", "eee", "ddd", "ccc", "ccc", "ccc", "eee", "aaa"])
+        ["eee", "aaa", "eee", "ddd", "ccc", "ccc", "ccc", "eee", "aaa"]
+    )
     cat = nvcategory.from_strings(strs)
     assert strs.size() == cat.size()
 
@@ -19,7 +21,7 @@ def test_keys():
     strs1 = nvstrings.to_device(["a", "b", "b", "f", "c", "f"])
     cat = nvcategory.from_strings(strs1)
     got = cat.keys()
-    expected = ['a', 'b', 'c', 'f']
+    expected = ["a", "b", "c", "f"]
     assert_eq(got, expected)
 
 
@@ -32,7 +34,8 @@ def test_keys_size():
 
 def test_values():
     strs = nvstrings.to_device(
-        ["eee", "aaa", "eee", "ddd", "ccc", "ccc", "ccc", "eee", "aaa"])
+        ["eee", "aaa", "eee", "ddd", "ccc", "ccc", "ccc", "eee", "aaa"]
+    )
     cat = nvcategory.from_strings(strs)
     got = cat.values()
     expected = [3, 0, 3, 2, 1, 1, 1, 3, 0]
@@ -41,7 +44,8 @@ def test_values():
 
 def test_value_for_index():
     strs = nvstrings.to_device(
-        ["eee", "aaa", "eee", "ddd", "ccc", "ccc", "ccc", "eee", "aaa"])
+        ["eee", "aaa", "eee", "ddd", "ccc", "ccc", "ccc", "eee", "aaa"]
+    )
     cat = nvcategory.from_strings(strs)
     got = cat.value_for_index(7)
     expected = 3
@@ -50,25 +54,28 @@ def test_value_for_index():
 
 def test_value():
     strs = nvstrings.to_device(
-        ["eee", "aaa", "eee", "ddd", "ccc", "ccc", "ccc", "eee", "aaa"])
+        ["eee", "aaa", "eee", "ddd", "ccc", "ccc", "ccc", "eee", "aaa"]
+    )
     cat = nvcategory.from_strings(strs)
-    got = cat.value('ccc')
+    got = cat.value("ccc")
     expected = 1
     assert got == expected
 
 
 def test_indexes_for_key():
     strs = nvstrings.to_device(
-        ["eee", "aaa", "eee", "ddd", "ccc", "ccc", "ccc", "eee", "aaa"])
+        ["eee", "aaa", "eee", "ddd", "ccc", "ccc", "ccc", "eee", "aaa"]
+    )
     cat = nvcategory.from_strings(strs)
-    got = cat.indexes_for_key('ccc')
+    got = cat.indexes_for_key("ccc")
     expected = [4, 5, 6]
     assert_eq(got, expected)
 
 
 def test_to_strings():
     strs = nvstrings.to_device(
-        ["eee", "aaa", "eee", "ddd", "ccc", "ccc", "ccc", "eee", "aaa"])
+        ["eee", "aaa", "eee", "ddd", "ccc", "ccc", "ccc", "eee", "aaa"]
+    )
     cat = nvcategory.from_strings(strs)
     got = cat.to_strings()
     assert_eq(got, strs)
@@ -76,10 +83,11 @@ def test_to_strings():
 
 def test_add_strings():
     strs = nvstrings.to_device(
-        ["eee", "aaa", "eee", "ddd", "ccc", "ccc", "ccc", "eee", "aaa"])
+        ["eee", "aaa", "eee", "ddd", "ccc", "ccc", "ccc", "eee", "aaa"]
+    )
     cat = nvcategory.from_strings(strs)
     got = cat.add_strings(strs)
-    expected_keys = ['aaa', 'ccc', 'ddd', 'eee']
+    expected_keys = ["aaa", "ccc", "ddd", "eee"]
     expected_values = [3, 0, 3, 2, 1, 1, 1, 3, 0, 3, 0, 3, 2, 1, 1, 1, 3, 0]
     assert_eq(got.keys(), expected_keys)
     assert_eq(got.values(), expected_values)
@@ -87,21 +95,32 @@ def test_add_strings():
 
 def test_gather_strings():
     strs = nvstrings.to_device(
-        ["eee", "aaa", "eee", "ddd", "ccc", "ccc", "ccc", "eee", "aaa"])
+        ["eee", "aaa", "eee", "ddd", "ccc", "ccc", "ccc", "eee", "aaa"]
+    )
     cat = nvcategory.from_strings(strs)
     got = cat.gather_strings([0, 2, 0])
-    expected = ['aaa', 'ddd', 'aaa']
+    expected = ["aaa", "ddd", "aaa"]
     assert_eq(got, expected)
+
+
+def test_gather_strings_exception():
+    strs = nvstrings.to_device(
+        ["eee", "aaa", "eee", "ddd", "ccc", "ccc", "ccc", "eee", "aaa"]
+    )
+    cat = nvcategory.from_strings(strs)
+    with pytest.raises(Exception):
+        cat.gather_strings([0, 2, 0, 4])
 
 
 def test_remove_strings():
     strs = nvstrings.to_device(
-        ["eee", "aaa", "eee", "ddd", "ccc", "ccc", "ccc", "eee", "aaa"])
+        ["eee", "aaa", "eee", "ddd", "ccc", "ccc", "ccc", "eee", "aaa"]
+    )
     cat = nvcategory.from_strings(strs)
     removal_strings = nvstrings.to_device(["ccc", "aaa", "bbb"])
     got = cat.remove_strings(removal_strings)
 
-    expected_keys = ['ddd', 'eee']
+    expected_keys = ["ddd", "eee"]
     expected_values = [1, 1, 0, 1]
     assert_eq(got.keys(), expected_keys)
     assert_eq(got.values(), expected_values)
@@ -109,12 +128,14 @@ def test_remove_strings():
 
 def test_from_strings():
     strs1 = nvstrings.to_device(
-        ["eee", "aaa", "eee", "ddd", "ccc", "ccc", "ccc", "eee", "aaa"])
+        ["eee", "aaa", "eee", "ddd", "ccc", "ccc", "ccc", "eee", "aaa"]
+    )
     strs2 = nvstrings.to_device(
-        ["ggg", "fff", "hhh", "aaa", "fff", "fff", "ggg", "hhh", "bbb"])
+        ["ggg", "fff", "hhh", "aaa", "fff", "fff", "ggg", "hhh", "bbb"]
+    )
     cat = nvcategory.from_strings(strs1, strs2)
 
-    expected_keys = ['aaa', 'bbb', 'ccc', 'ddd', 'eee', 'fff', 'ggg', 'hhh']
+    expected_keys = ["aaa", "bbb", "ccc", "ddd", "eee", "fff", "ggg", "hhh"]
     expected_values = [4, 0, 4, 3, 2, 2, 2, 4, 0, 6, 5, 7, 0, 5, 5, 6, 7, 1]
     assert_eq(cat.keys(), expected_keys)
     assert_eq(cat.values(), expected_values)
@@ -122,14 +143,16 @@ def test_from_strings():
 
 def test_merge_category():
     strs1 = nvstrings.to_device(
-        ["eee", "aaa", "eee", "ddd", "ccc", "ccc", "ccc", "eee", "aaa"])
+        ["eee", "aaa", "eee", "ddd", "ccc", "ccc", "ccc", "eee", "aaa"]
+    )
     strs2 = nvstrings.to_device(
-        ["ggg", "fff", "hhh", "aaa", "fff", "fff", "ggg", "hhh", "bbb"])
+        ["ggg", "fff", "hhh", "aaa", "fff", "fff", "ggg", "hhh", "bbb"]
+    )
     cat1 = nvcategory.from_strings(strs1)
     cat2 = nvcategory.from_strings(strs2)
     ncat = cat1.merge_category(cat2)
 
-    expected_keys = ['aaa', 'ccc', 'ddd', 'eee', 'bbb', 'fff', 'ggg', 'hhh']
+    expected_keys = ["aaa", "ccc", "ddd", "eee", "bbb", "fff", "ggg", "hhh"]
     expected_values = [3, 0, 3, 2, 1, 1, 1, 3, 0, 6, 5, 7, 0, 5, 5, 6, 7, 4]
     assert_eq(ncat.keys(), expected_keys)
     assert_eq(ncat.values(), expected_values)
@@ -137,14 +160,16 @@ def test_merge_category():
 
 def test_merge_and_remap():
     strs1 = nvstrings.to_device(
-        ["eee", "aaa", "eee", "ddd", "ccc", "ccc", "ccc", "eee", "aaa"])
+        ["eee", "aaa", "eee", "ddd", "ccc", "ccc", "ccc", "eee", "aaa"]
+    )
     strs2 = nvstrings.to_device(
-        ["ggg", "fff", "hhh", "aaa", "fff", "fff", "ggg", "hhh", "bbb"])
+        ["ggg", "fff", "hhh", "aaa", "fff", "fff", "ggg", "hhh", "bbb"]
+    )
     cat1 = nvcategory.from_strings(strs1)
     cat2 = nvcategory.from_strings(strs2)
     ncat = cat1.merge_and_remap(cat2)
 
-    expected_keys = ['aaa', 'bbb', 'ccc', 'ddd', 'eee', 'fff', 'ggg', 'hhh']
+    expected_keys = ["aaa", "bbb", "ccc", "ddd", "eee", "fff", "ggg", "hhh"]
     expected_values = [4, 0, 4, 3, 2, 2, 2, 4, 0, 6, 5, 7, 0, 5, 5, 6, 7, 1]
     assert_eq(ncat.keys(), expected_keys)
     assert_eq(ncat.values(), expected_values)
@@ -155,7 +180,7 @@ def test_add_keys():
     strs2 = nvstrings.to_device(["a", "b", "c", "d"])
     cat = nvcategory.from_strings(strs1)
     cat1 = cat.add_keys(strs2)
-    assert_eq(cat1.keys(), ['a', 'b', 'c', 'd', 'f'])
+    assert_eq(cat1.keys(), ["a", "b", "c", "d", "f"])
 
 
 def test_remove_keys():
@@ -163,7 +188,7 @@ def test_remove_keys():
     strs2 = nvstrings.to_device(["b", "d"])
     cat = nvcategory.from_strings(strs1)
     cat1 = cat.remove_keys(strs2)
-    assert_eq(cat1.keys(), ['a', 'c', 'f'])
+    assert_eq(cat1.keys(), ["a", "c", "f"])
 
 
 def test_set_keys():
@@ -171,7 +196,7 @@ def test_set_keys():
     strs2 = nvstrings.to_device(["b", "c", "e", "d"])
     cat = nvcategory.from_strings(strs1)
     cat1 = cat.set_keys(strs2)
-    assert_eq(cat1.keys(), ['b', 'c', 'd', 'e'])
+    assert_eq(cat1.keys(), ["b", "c", "d", "e"])
 
 
 def test_remove_unused_keys():
@@ -180,7 +205,7 @@ def test_remove_unused_keys():
     cat = nvcategory.from_strings(strs1)
     cat1 = cat.set_keys(strs2)
     cat1_unused_removed = cat1.remove_unused_keys()
-    assert_eq(cat1_unused_removed.keys(), ['b', 'c'])
+    assert_eq(cat1_unused_removed.keys(), ["b", "c"])
 
 
 def test_gather():
@@ -188,7 +213,7 @@ def test_gather():
     cat = nvcategory.from_strings(strs1)
     cat1 = cat.gather([1, 3, 2, 3, 1, 2])
 
-    expected_keys = ['a', 'b', 'c', 'f']
+    expected_keys = ["a", "b", "c", "f"]
     expected_values = [1, 3, 2, 3, 1, 2]
     assert_eq(cat1.keys(), expected_keys)
     assert_eq(cat1.values(), expected_values)
@@ -199,7 +224,7 @@ def test_gather_and_remap():
     cat = nvcategory.from_strings(strs1)
     cat1 = cat.gather_and_remap([1, 3, 2, 3, 1, 2])
 
-    expected_keys = ['b', 'c', 'f']
+    expected_keys = ["b", "c", "f"]
     expected_values = [0, 2, 1, 2, 0, 1]
     assert_eq(cat1.keys(), expected_keys)
     assert_eq(cat1.values(), expected_values)
@@ -209,26 +234,26 @@ def test_from_offsets():
     values = np.array([97, 112, 112, 108, 101], dtype=np.int8)
     offsets = np.array([0, 1, 2, 3, 4, 5], dtype=np.int32)
     cat = nvcategory.from_offsets(values, offsets, 5)
-    expected_keys = ['a', 'e', 'l', 'p']
+    expected_keys = ["a", "e", "l", "p"]
     expected_values = [0, 3, 3, 2, 1]
     assert_eq(cat.keys(), expected_keys)
     assert_eq(cat.values(), expected_values)
 
 
 def test_from_strings_list():
-    s1 = nvstrings.to_device(['apple', 'pear', 'banana'])
-    s2 = nvstrings.to_device(['orange', 'pear'])
+    s1 = nvstrings.to_device(["apple", "pear", "banana"])
+    s2 = nvstrings.to_device(["orange", "pear"])
     cat = nvcategory.from_strings_list([s1, s2])
 
-    expected_keys = ['apple', 'banana', 'orange', 'pear']
+    expected_keys = ["apple", "banana", "orange", "pear"]
     expected_values = [0, 3, 1, 2, 3]
     assert_eq(cat.keys(), expected_keys)
     assert_eq(cat.values(), expected_values)
 
 
 def test_to_device():
-    cat = nvcategory.to_device(['apple', 'pear', 'banana', 'orange', 'pear'])
-    expected_keys = ['apple', 'banana', 'orange', 'pear']
+    cat = nvcategory.to_device(["apple", "pear", "banana", "orange", "pear"])
+    expected_keys = ["apple", "banana", "orange", "pear"]
     expected_values = [0, 3, 1, 2, 3]
     assert_eq(cat.keys(), expected_keys)
     assert_eq(cat.values(), expected_values)

--- a/python/tests/test_memory.py
+++ b/python/tests/test_memory.py
@@ -6,20 +6,20 @@ from utils import assert_eq
 
 
 def test_from_csv():
-    tweets = nvstrings.from_csv(
-        '../../data/tweets.csv',
-        7)
+    tweets = nvstrings.from_csv("../../data/tweets.csv", 7)
     got = tweets[:5]
-    expected = ['@Bill_Porter nice to know that your site is back :-)',
-                '@sudhamshu after trying out various tools to take notes and I found that paper is the best to take notes and to maintain todo lists.',
-                '@neetashankar Yeah, I got the connection. I am getting 20 mbps for a 15 mbps connection. Customer service is also good.',
-                '@Bill_Porter All posts from your website http://t.co/NUWn5HUFsK seems to have been deleted. I am getting a ""Not Found"" page even in homepage',
-                'Today is ""bring your kids"" day at office and the entire office is taken over by cute little creatures ;)']
+    expected = [
+        "@Bill_Porter nice to know that your site is back :-)",
+        "@sudhamshu after trying out various tools to take notes and I found that paper is the best to take notes and to maintain todo lists.",
+        "@neetashankar Yeah, I got the connection. I am getting 20 mbps for a 15 mbps connection. Customer service is also good.",
+        '@Bill_Porter All posts from your website http://t.co/NUWn5HUFsK seems to have been deleted. I am getting a ""Not Found"" page even in homepage',
+        'Today is ""bring your kids"" day at office and the entire office is taken over by cute little creatures ;)',
+    ]
 
     assert_eq(got, expected)
 
 
 def test_free():
     # TODO: Check that GPU memory has been freed.
-    data = nvstrings.to_device(['a', 'b', 'c', 'd'])
+    data = nvstrings.to_device(["a", "b", "c", "d"])
     nvstrings.free(data)


### PR DESCRIPTION
- Move the `catch` between the thread macros to catch the exception in the same threads as where they were raised. 
- Fixes #367
