### PR TITLE
[WIP]Add python bindings for device memory

### DIFF
--- a/python/cpp/pystrings.cpp
+++ b/python/cpp/pystrings.cpp
@@ -3767,6 +3767,17 @@ static PyObject* n_is_empty( PyObject* self, PyObject* args )
     return ret;
 }
 
+// return the total device memory used by nvstrings object
+static PyObject* n_device_memory( PyObject* self, PyObject* args )
+{
+    NVStrings* tptr = (NVStrings*)PyLong_AsVoidPtr(PyTuple_GetItem(args,0));
+    unsigned int mem_size  = 0;
+    Py_BEGIN_ALLOW_THREADS
+    mem_size = tptr->memsize();
+    Py_END_ALLOW_THREADS
+    return PyLong_FromLong(mem_size);
+}
+
 static PyObject* n_get_info( PyObject* self, PyObject* args )
 {
     NVStrings* tptr = (NVStrings*)PyLong_AsVoidPtr(PyTuple_GetItem(args,0));
@@ -3947,6 +3958,7 @@ static PyMethodDef s_Methods[] = {
     { "n_islower", n_islower, METH_VARARGS, "" },
     { "n_isupper", n_isupper, METH_VARARGS, "" },
     { "n_is_empty", n_is_empty, METH_VARARGS, "" },
+    { "n_device_memory", n_device_memory, METH_VARARGS, "" },
     { "n_get_info", n_get_info, METH_VARARGS, "" },
     { "n_url_encode", n_url_encode, METH_VARARGS, "" },
     { "n_url_decode", n_url_decode, METH_VARARGS, "" },

--- a/python/nvstrings.py
+++ b/python/nvstrings.py
@@ -529,6 +529,13 @@ class nvstrings:
         """
         return pyniNVStrings.n_size(self.m_cptr)
 
+    def device_memory(self):
+        """
+        The total device memory used by this instance
+        :return:
+        """
+        return pyniNVStrings.n_device_memory(self.m_cptr)
+
     def len(self, devptr=0):
         """
         Returns the number of characters of each string.


### PR DESCRIPTION
This pr adds  python bindings for device memory and closes https://github.com/rapidsai/custrings/issues/362

@davidwendt  I dont know how to write tests for this as i am unsure about the ground truth about the bytes being used. 

Currently the output is as follows:

```python
import nvstrings
>>> nvstrings.to_device(['a'*7]).device_memory()
24
>>> nvstrings.to_device(['ab'*7]).device_memory()
32
>>> nvstrings.to_device(['abc'*7]).device_memory()
40
>>> nvstrings.to_device(['abcd'*7]).device_memory()
48
```