### PR TITLE
[WIP] Feature: pairwise edit distance for each string on a given nvstrings object 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## New Features
 
 - PR #416 Added documentation on supported timestamp specifiers
+- PR #419 Added `edit_distance_matrix()` function to calculate pairwise edit distance for each string on a given nvstrings object.  
 
 ## Improvement
 

--- a/cpp/include/NVText.h
+++ b/cpp/include/NVText.h
@@ -142,7 +142,15 @@ public:
      * @return 0 if successful.
      */
     static unsigned int edit_distance( distance_type algo, NVStrings& strs1, NVStrings& strs2, unsigned int* results, bool devmem=true );
-
+    /**
+     * @brief Compute the edit distance between each pair of strings
+     * @param algo The edit distance algorithm to use for the computation.
+     * @param strs Strings to process.
+     * @param[in,out] results Array of distances, one per string.
+     * @param devmem True if results in device memory.
+     * @return 0 if successful.
+     */
+    static unsigned int edit_distance_matrix( distance_type algo, NVStrings& strs, unsigned int* results, bool devmem=true );
     /**
      * @brief Converts tokenized list of strings into instance with ngrams.
      * @param strs Tokens to make into ngrams.

--- a/cpp/src/text/edit_distance.cu
+++ b/cpp/src/text/edit_distance.cu
@@ -227,3 +227,60 @@ unsigned int NVText::edit_distance( distance_type algo, NVStrings& strs1, NVStri
     return 0;
 }
 
+unsigned int NVText::edit_distance_matrix( distance_type algo, NVStrings& strs, unsigned int* results, bool bdevmem )
+{
+    if( algo != levenshtein || target==0 || results==0 )
+        throw std::invalid_argument("invalid algorithm");
+    unsigned int count = strs.size();
+    if( count==0 )
+        return 0; // nothing to do
+    auto execpol = rmm::exec_policy(0);
+    // custring_view* d_target = custring_from_host(target);
+
+    // setup results vector
+    unsigned int* d_rtn = results;
+    if( !bdevmem )
+        d_rtn = device_alloc<unsigned int>(count*count,0);
+
+    // get the string pointers
+    rmm::device_vector<custring_view*> strings(count,nullptr);
+    custring_view** d_strings = strings.data().get();
+    strs.create_custring_index(d_strings);
+
+    for (unsigned int k = 0; k < count; k++)
+    {
+        // calculate the size of the compute-buffer: 6 * length of string
+        rmm::device_vector<size_t> sizes(count,0);
+        size_t* d_sizes = sizes.data().get();
+        const unsigned int char_cnt = d_strings[k].chars_count();
+        thrust::for_each_n(execpol->on(0), thrust::make_counting_iterator<unsigned int>(0), count,
+            [d_strings, char_cnt, d_sizes] __device__(unsigned int idx){
+                custring_view* dstr = d_strings[idx];
+                if( !dstr )
+                    return;
+                int len = dstr->chars_count();
+                if( char_cnt < len )
+                    len = char_cnt();
+                d_sizes[idx] = len * 3;
+            });
+        //
+        size_t bufsize = thrust::reduce(execpol->on(0), d_sizes, d_sizes+count );
+        rmm::device_vector<short> buffer(bufsize,0);
+        short* d_buffer = buffer.data().get();
+        rmm::device_vector<size_t> offsets(count,0);
+        size_t* d_offsets = offsets.data().get();
+        thrust::exclusive_scan(execpol->on(0), sizes.begin(), sizes.end(), offsets.begin() );
+        // compute edit distance
+        thrust::for_each_n(execpol->on(0), thrust::make_counting_iterator<unsigned int>(0), count,
+            editdistance_levenshtein_algorithm(d_strings, d_strings[k], d_buffer, d_offsets, d_rtn+count*k));
+        //
+
+    }
+    if( !bdevmem )
+    {
+        CUDA_TRY( cudaMemcpyAsync(results,d_rtn,count*count*sizeof(unsigned int),cudaMemcpyDeviceToHost))
+        RMM_FREE(d_rtn,0);
+    }
+    // RMM_FREE(d_target,0);
+    return 0;
+}

--- a/python/cpp/pytext.cpp
+++ b/python/cpp/pytext.cpp
@@ -492,6 +492,61 @@ static PyObject* n_normalize_spaces( PyObject* self, PyObject* args )
     return PyLong_FromVoidPtr((void*)strs);
 }
 
+static PyObject* n_edit_distance_matrix( PyObject* self, PyObject* args )
+{
+    PyObject* pystrs = PyTuple_GetItem(args,0);
+    NVStrings* strs = strings_from_object(pystrs);
+    if( strs==0 )
+        Py_RETURN_NONE;
+
+    unsigned int count = strs->size();
+    if( count < 2 )
+    {
+        PyErr_Format(PyExc_ValueError,"minimum two strings are required!");
+        Py_RETURN_NONE;
+    }
+
+    NVText::distance_type algo = NVText::levenshtein;
+    PyObject* pyalgo = PyTuple_GetItem(args,1);
+
+    if( pyalgo != Py_None )
+    {
+        int ialgo = (int)PyLong_AsLong(pyalgo);
+        if( ialgo != (int)NVText::levenshtein )
+        {
+            PyErr_Format(PyExc_ValueError,"unrecognized edit-distance algorithm");
+            Py_RETURN_NONE;
+        }
+    }
+
+    unsigned int* devptr = (unsigned int*)PyLong_AsVoidPtr(PyTuple_GetItem(args,2));
+    if( devptr )
+    {
+        Py_BEGIN_ALLOW_THREADS
+        NVText::edit_distance_matrix(NVText::levenshtein,*strs,devptr);
+        Py_END_ALLOW_THREADS
+        Py_RETURN_NONE;
+    }
+
+    // or fill in python list with host memory
+    PyObject* ret = PyList_New(count);
+    PyObject* tmp = PyList_New(count);
+
+    std::vector<unsigned int> v(count);
+    std::vector<std::vector<unsigned int>> rtn(count, v);
+    Py_BEGIN_ALLOW_THREADS
+    NVText::edit_distance_matrix(NVText::levenshtein, *strs, rtn.data(),false);
+    Py_END_ALLOW_THREADS
+    for(unsigned int row=0; row < count; row++)
+    {
+        for(unsigned int idx=0; idx < count; idx++)
+            PyList_SetItem(tmp, idx, PyLong_FromLong((long)rtn[row][idx]));
+
+        PyList_SetItem(ret, row, tmp);
+    }
+    return ret;
+}
+
 static PyObject* n_edit_distance( PyObject* self, PyObject* args )
 {
     PyObject* pystrs = PyTuple_GetItem(args,0);
@@ -661,6 +716,7 @@ static PyMethodDef s_Methods[] = {
     { "n_replace_tokens", n_replace_tokens, METH_VARARGS, "" },
     { "n_normalize_spaces", n_normalize_spaces, METH_VARARGS, "" },
     { "n_edit_distance", n_edit_distance, METH_VARARGS, "" },
+    { "n_edit_distance_matrix", n_edit_distance_matrix, METH_VARARGS, "" },
     { "n_create_ngrams", n_create_ngrams, METH_VARARGS, "" },
     { "n_scatter_count", n_scatter_count, METH_VARARGS, "" },
     { NULL, NULL, 0, NULL }

--- a/python/cpp/pytext.cpp
+++ b/python/cpp/pytext.cpp
@@ -530,17 +530,16 @@ static PyObject* n_edit_distance_matrix( PyObject* self, PyObject* args )
 
     // or fill in python list with host memory
     PyObject* ret = PyList_New(count);
-    PyObject* tmp = PyList_New(count);
 
-    std::vector<unsigned int> v(count);
-    std::vector<std::vector<unsigned int>> rtn(count, v);
+    std::vector<unsigned int> rtn(count*count);
     Py_BEGIN_ALLOW_THREADS
     NVText::edit_distance_matrix(NVText::levenshtein, *strs, rtn.data(),false);
     Py_END_ALLOW_THREADS
     for(unsigned int row=0; row < count; row++)
     {
+        PyObject* tmp = PyList_New(count);
         for(unsigned int idx=0; idx < count; idx++)
-            PyList_SetItem(tmp, idx, PyLong_FromLong((long)rtn[row][idx]));
+            PyList_SetItem(tmp, idx, PyLong_FromLong((long)rtn[row*count+idx]));
 
         PyList_SetItem(ret, row, tmp);
     }

--- a/python/nvtext.py
+++ b/python/nvtext.py
@@ -307,9 +307,9 @@ def edit_distance_matrix(strs, algo=0, devptr=0):
     >>> s = nvstrings.to_device(["honda","hyundai","suzuki"])
     >>> n = nvtext.edit_distance_matrix(s)
     >>> print(n)
-    [[0, 3, 11],
-     [3, 0, *],
-     [11, *, 0]]
+    [[0, 3, 6],
+     [3, 0, 5],
+     [6, 5, 0]]
 
     """
     rtn = pyniNVText.n_edit_distance_matrix(strs, algo, devptr)

--- a/python/nvtext.py
+++ b/python/nvtext.py
@@ -287,6 +287,35 @@ def edit_distance(strs, tgt, algo=0, devptr=0):
     return rtn
 
 
+def edit_distance_matrix(strs, algo=0, devptr=0):
+    """
+    Compute the edit-distance between each pair of strings in strs .
+    Edit distance is how many character changes between strings.
+
+    Parameters
+    ----------
+    strs : nvstrings
+        The strings for this operation.
+    algo: int
+        0 = Levenshtein
+    devptr : GPU memory pointer
+        Must be able to hold at least strs.size() of int32 values.
+
+    Examples
+    --------
+    >>> import nvstrings, nvtext
+    >>> s = nvstrings.to_device(["honda","hyundai","suzuki"])
+    >>> n = nvtext.edit_distance_matrix(s)
+    >>> print(n)
+    [[0, 3, 11],
+     [3, 0, *],
+     [11, *, 0]]
+
+    """
+    rtn = pyniNVText.n_edit_distance_matrix(strs, algo, devptr)
+    return rtn
+
+
 def ngrams(tokens, N=2, sep="_"):
     """
     Generate the n-grams from a set of tokens.

--- a/python/tests/test_text.py
+++ b/python/tests/test_text.py
@@ -224,6 +224,16 @@ def test_edit_distance():
     assert distance_outcomes == expected
 
 
+def test_edit_distance_matrix():
+
+    strs = nvstrings.to_device(
+        ["my least favorite sentence", "fish", "software"]
+    )
+    distance_outcomes = nvtext.edit_distance_matrix(strs, algo=0)
+    expected = [[0, 23, 22], [23, 0, 7], [22, 7, 0]]
+    assert distance_outcomes == expected
+
+
 def test_ngrams():
     # bigrams
     strings = ["this is my favorite", "book on my bookshelf"]


### PR DESCRIPTION
This PR implements the `edit_distance_matrix()` function that computes pairwise distance on a list of strings(i.e. nvstrings object) and returns a distance matrix. 
Recently, I was working on a strings related use-case and where I felt the need of this function...

Example:
```python
import nvstrings, nvtext
s = nvstrings.to_device(["honda","hyundai","suzuki"])
n = nvtext.edit_distance_matrix(s)
print(n)
Out:    
[[0, 3, 6],
 [3, 0, 5],
 [6, 5, 0]]
```

