### PR TITLE
[WIP] Fix sublist fail with slice bigger than size of the string array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 - PR #413 Fixed get_info character formating
 - PR #412 Fixed bug in compare when used with non-ascii character
 - PR #414 Fixed memory leaks in urldecode() and insert()
+- PR #422 Fix sublist fail with slice bigger than size of the string array
+
 
 # cuStrings/nvStrings 0.9.0 (21 Aug 2019)
 

--- a/python/nvstrings.py
+++ b/python/nvstrings.py
@@ -423,6 +423,8 @@ class nvstrings:
             end = self.size() if key.stop is None else key.stop
             step = 1 if key.step is None or key.step == 0 else key.step
             # negative slicing check
+            start = -1 * self.size() if (start < -1 * self.size()) else start
+            end = -1 * self.size() if (end < -1 * self.size()) else end
             end = self.size() + end if end < 0 else end
             start = self.size() + start if start < 0 else start
             rtn = pyniNVStrings.n_sublist(self.m_cptr, start, end, step)

--- a/python/tests/test_substr.py
+++ b/python/tests/test_substr.py
@@ -19,6 +19,15 @@ def test_slice_from():
     assert_eq(got, expected)
 
 
+def test_slice_negative_start():
+    strs = nvstrings.to_device(
+        ["a", "b"]
+    )
+    got = strs[slice(-3, None, None)]
+    expected = ["a", "b"]
+    assert_eq(got, expected)
+
+
 @pytest.mark.parametrize("start", [2, 2, 2, 2])
 @pytest.mark.parametrize("stop", [8, 15, 8, 8])
 @pytest.mark.parametrize("step", [None, None, 2, 5])


### PR DESCRIPTION
For the following example the earlier code was failing,

```
import nvstrings
s = nvstrings.to_device(["a", "b"])
s[slice(-3, None, None)]
```

code change was handle this scenario and test case has been added to validate this scenario.
close #421 